### PR TITLE
Release 0.3.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -106,10 +106,10 @@ module "eks" {
     }
   }
 
-  cluster_encryption_config = [{
+  cluster_encryption_config = {
     provider_key_arn = aws_kms_key.this.arn
     resources        = ["secrets"]
-  }]
+  }
 
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 

--- a/main.tf
+++ b/main.tf
@@ -31,18 +31,6 @@ locals {
       cidr_blocks = ["0.0.0.0/0"]
     }
   }
-
-  # AWS Load Balancer Controller needs these additional security groups to work.
-  load_balancer_security_group_rules = {
-    ingress_cluster_9443 = {
-      description                   = "Cluster webooks to node groups"
-      protocol                      = "tcp"
-      from_port                     = 9443
-      to_port                       = 9443
-      type                          = "ingress"
-      source_cluster_security_group = true
-    }
-  }
 }
 
 resource "aws_kms_key" "this" {
@@ -123,7 +111,6 @@ module "eks" {
 
   node_security_group_additional_rules = merge(
     local.cert_manager ? local.cert_manager_security_group_rules : {},
-    local.load_balancer_security_group_rules,
     var.node_security_group_additional_rules
   )
 

--- a/main.tf
+++ b/main.tf
@@ -105,17 +105,17 @@ module "eks" {
     resources        = ["secrets"]
   }
 
-  cluster_endpoint_public_access = true
-  create_kms_key                 = false
-
+  cluster_endpoint_private_access         = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access          = var.cluster_endpoint_public_access
+  cluster_endpoint_public_access_cidrs    = var.cluster_endpoint_public_access_cidrs
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 
   aws_auth_roles            = local.aws_auth_roles
+  create_kms_key            = false
   manage_aws_auth_configmap = true
-
-  enable_irsa = true
-  subnet_ids  = concat(var.public_subnets, var.private_subnets)
-  vpc_id      = var.vpc_id
+  enable_irsa               = true
+  subnet_ids                = concat(var.public_subnets, var.private_subnets)
+  vpc_id                    = var.vpc_id
 
   node_security_group_additional_rules = merge(
     local.cert_manager ? local.cert_manager_security_group_rules : {},

--- a/main.tf
+++ b/main.tf
@@ -110,6 +110,7 @@ module "eks" {
     provider_key_arn = aws_kms_key.this.arn
     resources        = ["secrets"]
   }
+  create_kms_key = false
 
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "aws_kms_key" "this" {
 
 module "eks_security_group" {
   source  = "terraform-aws-modules/security-group/aws"
-  version = "4.13.1"
+  version = "4.16.2"
 
   ingress_cidr_blocks = [var.vpc_cidr]
   name                = var.cluster_name
@@ -88,7 +88,7 @@ resource "aws_security_group" "eks_efs_sg" {
 # EKS Cluster
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "18.30.1"
+  version = "19.5.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version
@@ -158,7 +158,7 @@ resource "null_resource" "eks_kubeconfig" {
 # Authorize Amazon Load Balancer Controller
 module "eks_lb_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true
@@ -176,7 +176,7 @@ module "eks_lb_irsa" {
 # Authorize VPC CNI via IRSA.
 module "eks_vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name             = "${var.cluster_name}-vpc-cni-role"
   attach_vpc_cni_policy = true
@@ -195,7 +195,7 @@ module "eks_vpc_cni_irsa" {
 # Allow PVCs backed by EBS
 module "eks_ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true
@@ -213,7 +213,7 @@ module "eks_ebs_csi_irsa" {
 # Allow PVCs backed by EFS
 module "eks_efs_csi_controller_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name             = "${var.cluster_name}-efs-csi-controller-role"
   attach_efs_csi_policy = true
@@ -231,7 +231,7 @@ module "eks_efs_csi_controller_irsa" {
 
 module "eks_efs_csi_node_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name = "${var.cluster_name}-efs-csi-node-role"
   oidc_providers = {
@@ -576,7 +576,7 @@ resource "null_resource" "eks_nvidia_device_plugin" {
 module "cert_manager_irsa" {
   count   = local.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.5.1"
+  version = "5.9.2"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,13 @@ module "eks" {
   cluster_version = var.kubernetes_version
 
   cluster_addons = {
+    preserve    = true
+    most_recent = true
+    timeouts = {
+      create = "25m"
+      delete = "10m"
+    }
+
     coredns    = {}
     kube-proxy = {}
     vpc-cni = {

--- a/main.tf
+++ b/main.tf
@@ -82,20 +82,24 @@ module "eks" {
   cluster_version = var.kubernetes_version
 
   cluster_addons = {
-    preserve    = true
-    most_recent = true
-    timeouts = {
-      create = "25m"
-      delete = "10m"
+    coredns = {
+      most_recent = true
+      preserve    = true
     }
-
-    coredns    = {}
-    kube-proxy = {}
+    kube-proxy = {
+      most_recent = true
+      preserve    = true
+    }
     vpc-cni = {
+      most_recent              = true
+      preserve                 = true
       service_account_role_arn = module.eks_vpc_cni_irsa.iam_role_arn
     }
   }
-
+  cluster_addons_timeouts = {
+    create = "25m"
+    delete = "10m"
+  }
   cluster_encryption_config = {
     provider_key_arn = aws_kms_key.this.arn
     resources        = ["secrets"]

--- a/main.tf
+++ b/main.tf
@@ -96,10 +96,7 @@ module "eks" {
       service_account_role_arn = module.eks_vpc_cni_irsa.iam_role_arn
     }
   }
-  cluster_addons_timeouts = {
-    create = "25m"
-    delete = "10m"
-  }
+  cluster_addons_timeouts = var.cluster_addons_timeouts
   cluster_encryption_config = {
     provider_key_arn = aws_kms_key.this.arn
     resources        = ["secrets"]

--- a/main.tf
+++ b/main.tf
@@ -76,7 +76,7 @@ resource "aws_security_group" "eks_efs_sg" {
 # EKS Cluster
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.5.0"
+  version = "19.5.1"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/main.tf
+++ b/main.tf
@@ -83,15 +83,15 @@ module "eks" {
 
   cluster_addons = {
     coredns = {
-      most_recent = true
+      most_recent = var.cluster_addons_most_recent
       preserve    = true
     }
     kube-proxy = {
-      most_recent = true
+      most_recent = var.cluster_addons_most_recent
       preserve    = true
     }
     vpc-cni = {
-      most_recent              = true
+      most_recent              = var.cluster_addons_most_recent
       preserve                 = true
       service_account_role_arn = module.eks_vpc_cni_irsa.iam_role_arn
     }

--- a/main.tf
+++ b/main.tf
@@ -82,14 +82,9 @@ module "eks" {
   cluster_version = var.kubernetes_version
 
   cluster_addons = {
-    coredns = {
-      resolve_conflicts = "OVERWRITE"
-    }
-    kube-proxy = {
-      resolve_conflicts = "OVERWRITE"
-    }
+    coredns    = {}
+    kube-proxy = {}
     vpc-cni = {
-      resolve_conflicts        = "OVERWRITE"
       service_account_role_arn = module.eks_vpc_cni_irsa.iam_role_arn
     }
   }
@@ -98,7 +93,9 @@ module "eks" {
     provider_key_arn = aws_kms_key.this.arn
     resources        = ["secrets"]
   }
-  create_kms_key = false
+
+  cluster_endpoint_public_access = true
+  create_kms_key                 = false
 
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 

--- a/main.tf
+++ b/main.tf
@@ -296,7 +296,7 @@ provider "helm" {
       api_version = "client.authentication.k8s.io/v1beta1"
       command     = "aws"
       # This requires the awscli to be installed locally where Terraform is executed
-      args = ["eks", "get-token", "--region", local.aws_region, "--cluster-name", module.eks.cluster_id]
+      args = ["eks", "get-token", "--region", local.aws_region, "--cluster-name", module.eks.cluster_name]
     }
   }
 }
@@ -308,7 +308,7 @@ provider "kubernetes" {
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
     command     = "aws"
-    args        = ["eks", "get-token", "--region", local.aws_region, "--cluster-name", module.eks.cluster_id]
+    args        = ["eks", "get-token", "--region", local.aws_region, "--cluster-name", module.eks.cluster_name]
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,16 @@ output "eks_managed_node_groups" {
   value       = module.eks.eks_managed_node_groups
 }
 
+output "node_security_group_arn" {
+  description = "ARN of the EKS node shared security group"
+  value       = module.eks.node_security_group_arn
+}
+
+output "node_security_group_id" {
+  description = "ID of the EKS node shared security group"
+  value       = module.eks.node_security_group_id
+}
+
 output "oidc_provider" {
   description = "The OpenID Connect identity provider (issuer URL without leading `https://`)"
   value       = module.eks.oidc_provider

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,11 @@ output "eks_managed_node_groups" {
   value       = module.eks.eks_managed_node_groups
 }
 
+output "kms_key_arn" {
+  description = "The Amazon Resource Name (ARN) of the KMS key for the EKS cluster."
+  value       = aws_kms_key.this.arn
+}
+
 output "node_security_group_arn" {
   description = "ARN of the EKS node shared security group"
   value       = module.eks.node_security_group_arn

--- a/variables.tf
+++ b/variables.tf
@@ -4,7 +4,7 @@ variable "cluster_name" {
 }
 
 variable "cert_manager_version" {
-  default     = "1.9.1"
+  default     = "1.10.1"
   description = "Version of cert-manager to install."
   type        = string
 }
@@ -55,13 +55,13 @@ variable "default_max_size" {
 }
 
 variable "ebs_csi_driver_version" {
-  default     = "2.12.0"
+  default     = "2.14.1"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.2.9"
+  default     = "2.3.5"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
@@ -72,7 +72,7 @@ variable "eks_managed_node_groups" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.23"
+  default     = "1.24"
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
 }
@@ -84,7 +84,7 @@ variable "iam_role_attach_cni_policy" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.4.5"
+  default     = "1.4.6"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }
@@ -131,7 +131,7 @@ variable "nvidia_device_plugin" {
 }
 
 variable "nvidia_device_plugin_version" {
-  default     = "0.12.3"
+  default     = "0.13.0"
   description = "Version of the Nvidia device plugin to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,3 @@
-variable "cluster_name" {
-  description = "Unique name for the EKS cluster."
-  type        = string
-}
-
 variable "cert_manager_version" {
   default     = "1.10.1"
   description = "Version of cert-manager to install."
@@ -13,6 +8,29 @@ variable "cert_manager_route53_zone_id" {
   default     = ""
   description = "Configure cert-manager to issue certificates for this Route53 DNS Zone when provided"
   type        = string
+}
+
+variable "cluster_name" {
+  description = "Unique name for the EKS cluster."
+  type        = string
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Indicates whether or not the Amazon EKS private API server endpoint is enabled"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_endpoint_public_access" {
+  description = "Indicates whether or not the Amazon EKS public API server endpoint is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "cluster_endpoint_public_access_cidrs" {
+  description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint"
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
 }
 
 # The ECR repository is not the same for every region, in particular

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,12 @@ variable "cert_manager_route53_zone_id" {
   type        = string
 }
 
+variable "cluster_addons_most_recent" {
+  description = "Indicates whether to use the most recent version of cluster addons"
+  type        = bool
+  default     = true
+}
+
 variable "cluster_addons_timeouts" {
   description = "Create, update, and delete timeout configurations for the cluster addons"
   type        = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -10,9 +10,14 @@ variable "cert_manager_route53_zone_id" {
   type        = string
 }
 
-variable "cluster_name" {
-  description = "Unique name for the EKS cluster."
-  type        = string
+variable "cluster_addons_timeouts" {
+  description = "Create, update, and delete timeout configurations for the cluster addons"
+  type        = map(string)
+  default = {
+    create = "25m"
+    delete = "10m"
+    update = "15m"
+  }
 }
 
 variable "cluster_endpoint_private_access" {
@@ -31,6 +36,11 @@ variable "cluster_endpoint_public_access_cidrs" {
   description = "List of CIDR blocks which can access the Amazon EKS public API server endpoint"
   type        = list(string)
   default     = ["0.0.0.0/0"]
+}
+
+variable "cluster_name" {
+  description = "Unique name for the EKS cluster."
+  type        = string
 }
 
 # The ECR repository is not the same for every region, in particular


### PR DESCRIPTION
Upgrade EKS module to [19.5.1](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v19.5.1) and implement the [upgrade notes](https://github.com/terraform-aws-modules/terraform-aws-eks/blob/master/docs/UPGRADE-19.0.md).  In particular:
  * The load balancer 9443 workaround has been adopted upstream.
  * Default to configuring clusters with public API access, but expose new variables that allow configuring private access as well added in 19.x.
  * Configure to use latest version of cluster addons, and add variable for their defaults.
  * 19.x creates a KMS by default, which is disabled here.

Upgrade EBS, EFS, load balancer, and nvidia drivers to their latest version; use 1.24 as the default EKS version.