### PR TITLE
Release 0.5.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_security_group" "eks_efs_sg" {
 # EKS Cluster
 module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-no-public-cluster-access tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.10.0"
+  version = "19.10.1"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version
@@ -113,7 +113,7 @@ resource "null_resource" "eks_kubeconfig" {
 # Authorize Amazon Load Balancer Controller
 module "eks_lb_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true
@@ -131,7 +131,7 @@ module "eks_lb_irsa" {
 # Authorize VPC CNI via IRSA.
 module "eks_vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name             = "${var.cluster_name}-vpc-cni-role"
   attach_vpc_cni_policy = true
@@ -150,7 +150,7 @@ module "eks_vpc_cni_irsa" {
 # Allow PVCs backed by EBS
 module "eks_ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true
@@ -168,7 +168,7 @@ module "eks_ebs_csi_irsa" {
 # Allow PVCs backed by EFS
 module "eks_efs_csi_controller_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name             = "${var.cluster_name}-efs-csi-controller-role"
   attach_efs_csi_policy = true
@@ -186,7 +186,7 @@ module "eks_efs_csi_controller_irsa" {
 
 module "eks_efs_csi_node_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name = "${var.cluster_name}-efs-csi-node-role"
   oidc_providers = {
@@ -438,7 +438,7 @@ resource "null_resource" "eks_nvidia_device_plugin" {
 module "cert_manager_irsa" {
   count   = local.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.12.0"
+  version = "5.14.2"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/main.tf
+++ b/main.tf
@@ -357,6 +357,7 @@ resource "kubernetes_annotations" "eks_disable_gp2" {
   annotations = {
     "storageclass.kubernetes.io/is-default-class" = "false"
   }
+  force = true
 
   depends_on = [
     kubernetes_storage_class.eks_ebs_storage_class

--- a/variables.tf
+++ b/variables.tf
@@ -95,13 +95,13 @@ variable "default_max_size" {
 }
 
 variable "ebs_csi_driver_version" {
-  default     = "2.17.1"
+  default     = "2.17.2"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.4.0"
+  default     = "2.4.1"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }


### PR DESCRIPTION
### Bug Fixes

* Fix regression from #7, need to add `force` parameter to the `kubernetes_annotations` resource to prevent errors like:

    ```
    ╷
    │ Error: Field manager conflict
    │ 
    │   with module.eks.kubernetes_annotations.eks_disable_gp2,
    │   on .terraform/modules/eks/main.tf line 351, in resource "kubernetes_annotations" "eks_disable_gp2":
    │  351: resource "kubernetes_annotations" "eks_disable_gp2" {
    │ 
    │ Another client is managing a field Terraform tried to update. Set "force" to true to override: 
    │   Apply failed with 1 conflict: conflict with "kubectl-client-side-apply" using storage.k8s.io/v1: .metadata.annotations.storageclass.kubernetes.io/is-default-class
    ╵
    ```

### Terraform Module Upgrades

* [`aws-eks` v19.10.1](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v19.10.1)
* [`aws-iam` v5.14.2](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.14.2)

### Helm Chart Upgrades
    
* [AWS EBS CSI Controller v2.17.2](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.17.2)
* [AWS EFS CSI Controller v2.4.1](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.4.1)