### PR TITLE
Release 0.5.5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_security_group" "eks_efs_sg" {
 # EKS Cluster
 module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-no-public-cluster-access tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
   source  = "terraform-aws-modules/eks/aws"
-  version = "19.13.0"
+  version = "19.15.3"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "null_resource" "eks_kubeconfig" {
 # Authorize Amazon Load Balancer Controller
 module "eks_lb_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true
@@ -131,7 +131,7 @@ module "eks_lb_irsa" {
 # Authorize VPC CNI via IRSA.
 module "eks_vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name             = "${var.cluster_name}-vpc-cni-role"
   attach_vpc_cni_policy = true
@@ -150,7 +150,7 @@ module "eks_vpc_cni_irsa" {
 # Allow PVCs backed by EBS
 module "eks_ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true
@@ -168,7 +168,7 @@ module "eks_ebs_csi_irsa" {
 # Allow PVCs backed by EFS
 module "eks_efs_csi_controller_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name             = "${var.cluster_name}-efs-csi-controller-role"
   attach_efs_csi_policy = true
@@ -186,7 +186,7 @@ module "eks_efs_csi_controller_irsa" {
 
 module "eks_efs_csi_node_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name = "${var.cluster_name}-efs-csi-node-role"
   oidc_providers = {
@@ -438,7 +438,7 @@ resource "null_resource" "eks_nvidia_device_plugin" {
 module "cert_manager_irsa" {
   count   = local.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.17.0"
+  version = "5.27.0"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "ebs_csi_driver_version" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.4.6"
+  default     = "2.4.7"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -118,7 +118,7 @@ variable "helm_verify" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.26"
+  default     = "1.27"
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -95,13 +95,13 @@ variable "default_max_size" {
 }
 
 variable "ebs_csi_driver_version" {
-  default     = "2.18.0"
+  default     = "2.20.0"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.4.1"
+  default     = "2.4.6"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
@@ -130,7 +130,7 @@ variable "iam_role_attach_cni_policy" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.5.2"
+  default     = "1.5.4"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 variable "cert_manager_version" {
-  default     = "1.11.0"
+  default     = "1.12.2"
   description = "Version of cert-manager to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -177,7 +177,7 @@ variable "nvidia_device_plugin" {
 }
 
 variable "nvidia_device_plugin_version" {
-  default     = "0.13.0"
+  default     = "0.14.0"
   description = "Version of the Nvidia device plugin to install."
   type        = string
 }


### PR DESCRIPTION
### Terraform Module Upgrades

* [`aws-eks` v19.15.3](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v19.15.3)
* [`aws-iam` v5.27.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.27.0)

### Helm Chart Upgrades
    
* [AWS EBS CSI Controller v2.20.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.20.0)
* [AWS EFS CSI Controller ~~v2.4.6~~ v2.4.7](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.4.7)
* [AWS Load Balancer Controller v1.5.4](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.5.3)
* [`cert-manager` v1.12.2](https://github.com/cert-manager/cert-manager/releases/tag/v1.12.2)

### Other

* Default Kubernetes version to 1.27.
* Nvidia device plugin upgraded to [0.14.0](https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.14.0), cc @tlpinney.