### PR TITLE
Release 0.5.6

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ resource "null_resource" "eks_kubeconfig" {
 # Authorize Amazon Load Balancer Controller
 module "eks_lb_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true
@@ -131,7 +131,7 @@ module "eks_lb_irsa" {
 # Authorize VPC CNI via IRSA.
 module "eks_vpc_cni_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name             = "${var.cluster_name}-vpc-cni-role"
   attach_vpc_cni_policy = true
@@ -150,7 +150,7 @@ module "eks_vpc_cni_irsa" {
 # Allow PVCs backed by EBS
 module "eks_ebs_csi_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true
@@ -168,7 +168,7 @@ module "eks_ebs_csi_irsa" {
 # Allow PVCs backed by EFS
 module "eks_efs_csi_controller_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name             = "${var.cluster_name}-efs-csi-controller-role"
   attach_efs_csi_policy = true
@@ -186,7 +186,7 @@ module "eks_efs_csi_controller_irsa" {
 
 module "eks_efs_csi_node_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name = "${var.cluster_name}-efs-csi-node-role"
   oidc_providers = {
@@ -438,7 +438,7 @@ resource "null_resource" "eks_nvidia_device_plugin" {
 module "cert_manager_irsa" {
   count   = local.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.27.0"
+  version = "5.28.0"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -95,7 +95,7 @@ variable "default_max_size" {
 }
 
 variable "ebs_csi_driver_version" {
-  default     = "2.20.0"
+  default     = "2.21.0"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
@@ -130,7 +130,7 @@ variable "iam_role_attach_cni_policy" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.5.4"
+  default     = "1.5.5"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }
@@ -177,7 +177,7 @@ variable "nvidia_device_plugin" {
 }
 
 variable "nvidia_device_plugin_version" {
-  default     = "0.14.0"
+  default     = "0.14.1"
   description = "Version of the Nvidia device plugin to install."
   type        = string
 }


### PR DESCRIPTION
### Terraform Module Upgrades

* [`aws-iam` v5.28.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.27.0)

### Helm Chart Upgrades
    
* [AWS EBS CSI Controller v2.21.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.21.0)
* [AWS Load Balancer Controller v1.5.5](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.5.4)

### Other

* Nvidia device plugin upgraded to [0.14.1](https://github.com/NVIDIA/k8s-device-plugin/releases/tag/v0.14.1)