### PR TITLE
Release 0.6.1

### DIFF
--- a/cni.tf
+++ b/cni.tf
@@ -1,5 +1,6 @@
 # Authorize VPC CNI via IRSA.
 module "eks_vpc_cni_irsa" {
+  count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.33.0"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -1,0 +1,59 @@
+## Crossplane
+locals {
+  crossplane = length(var.crossplane_policy_arns) > 0
+}
+
+module "crossplane_irsa" {
+  count   = local.crossplane ? 1 : 0
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.33.0"
+
+  role_name = "${var.cluster_name}-crossplane-role"
+
+  oidc_providers = {
+    main = {
+      provider_arn = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "${var.crossplane_namespace}:crossplane-system:provider-aws-*",
+      ]
+    }
+  }
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "crossplane" {
+  count      = local.crossplane ? length(var.crossplane_policy_arns) : 0
+  role       = "${var.cluster_name}-crossplane-role"
+  policy_arn = aws_iam_policy.crossplane[*].arn
+  depends_on = [
+    module.crossplane_irsa[0]
+  ]
+}
+
+resource "helm_release" "crossplane" {
+  count            = local.crossplane ? 1 : 0
+  name             = "crossplane"
+  namespace        = var.crossplane_namespace
+  create_namespace = var.crossplane_namespace == "kube-system" ? false : true
+  chart            = "crossplane"
+  repository       = "https://charts.crossplane.io/stable"
+  version          = var.crossplane_version
+  wait             = var.crossplane_wait
+  verify           = var.helm_verify
+
+  values = [
+    yamlencode({
+      "serviceAccount" = {
+        "annotations" = {
+          "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-crossplane-role"
+        }
+      }
+    }),
+    yamlencode(var.crossplane_values),
+  ]
+
+  depends_on = [
+    module.crossplane_irsa[0],
+    module.eks,
+  ]
+}

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -24,7 +24,7 @@ module "crossplane_irsa" {
 resource "aws_iam_role_policy_attachment" "crossplane" {
   count      = local.crossplane ? length(var.crossplane_policy_arns) : 0
   role       = "${var.cluster_name}-crossplane-role"
-  policy_arn = aws_iam_policy.crossplane[*].arn
+  policy_arn = var.crossplane_policy_arns[count.index]
   depends_on = [
     module.crossplane_irsa[0]
   ]

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -42,8 +42,8 @@ resource "helm_release" "crossplane" {
 
   values = [
     yamlencode({
-      "serviceAccount" = {
-        "annotations" = {
+      serviceAccount = {
+        annotations = {
           "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-crossplane-role"
         }
       }

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -1,10 +1,6 @@
 ## Crossplane
-locals {
-  crossplane = length(var.crossplane_policy_arns) > 0
-}
-
 module "crossplane_irsa" {
-  count   = local.crossplane ? 1 : 0
+  count   = var.crossplane ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.33.0"
 
@@ -22,7 +18,7 @@ module "crossplane_irsa" {
 }
 
 resource "aws_iam_role_policy_attachment" "crossplane" {
-  count      = local.crossplane ? length(var.crossplane_policy_arns) : 0
+  count      = var.crossplane ? length(var.crossplane_policy_arns) : 0
   role       = "${var.cluster_name}-crossplane-role"
   policy_arn = var.crossplane_policy_arns[count.index]
   depends_on = [
@@ -31,7 +27,7 @@ resource "aws_iam_role_policy_attachment" "crossplane" {
 }
 
 resource "helm_release" "crossplane" {
-  count            = local.crossplane ? 1 : 0
+  count            = var.crossplane ? 1 : 0
   name             = "crossplane"
   namespace        = var.crossplane_namespace
   create_namespace = var.crossplane_namespace == "kube-system" ? false : true

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -39,7 +39,6 @@ resource "helm_release" "crossplane" {
   repository       = "https://charts.crossplane.io/stable"
   version          = var.crossplane_version
   wait             = var.crossplane_wait
-  verify           = var.helm_verify
 
   values = [
     yamlencode({

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -64,8 +64,8 @@ resource "kubernetes_storage_class" "eks_ebs_storage_class" {
     name   = "ebs-sc"
   }
 
-  mount_options       = []
-  parameters          = {}
+  mount_options       = var.ebs_storage_class_mount_options
+  parameters          = var.ebs_storage_class_parameters
   storage_provisioner = "ebs.csi.aws.com"
   volume_binding_mode = "WaitForFirstConsumer"
 

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -159,7 +159,6 @@ resource "helm_release" "aws_efs_csi_driver" {
   version          = var.efs_csi_driver_version
   wait             = var.efs_csi_driver_wait
 
-
   values = [
     yamlencode({
       "controller" = {
@@ -199,13 +198,10 @@ resource "kubernetes_storage_class" "eks_efs_storage_class" {
     labels      = {}
   }
 
-  mount_options = []
-  parameters = {
-    "provisioningMode" = "efs-ap"
-    "fileSystemId"     = aws_efs_file_system.eks_efs[0].id
-    "directoryPerms"   = "755"
-    "uid"              = "0"
-    "gid"              = "0"
+  mount_options = var.efs_storage_class_mount_options
+  parameters = merge(
+    var.efs_storage_class_parameters,
+    { "fileSystemId" = aws_efs_file_system.eks_efs[0].id }
   }
   storage_provisioner = "efs.csi.aws.com"
 

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -202,7 +202,7 @@ resource "kubernetes_storage_class" "eks_efs_storage_class" {
   parameters = merge(
     var.efs_storage_class_parameters,
     { "fileSystemId" = aws_efs_file_system.eks_efs[0].id }
-  }
+  )
   storage_provisioner = "efs.csi.aws.com"
 
   depends_on = [

--- a/main.tf
+++ b/main.tf
@@ -3,6 +3,9 @@ data "aws_partition" "current" {}
 data "aws_region" "current" {}
 
 locals {
+  addon_defaults = {
+    most_recent = var.cluster_addons_most_recent
+  }
   aws_account_id = data.aws_caller_identity.current.account_id
   aws_partition  = data.aws_partition.current.partition
   aws_region     = data.aws_region.current.name
@@ -27,6 +30,21 @@ locals {
     local.aws_auth_karpenter_roles,
     var.aws_auth_roles
   )
+  coredns_addon_defaults = var.coredns_fargate ? {
+    configuration_values = jsonencode({
+      computeType = "Fargate"
+      resources = {
+        limits = {
+          cpu    = "0.25"
+          memory = "256M"
+        }
+        requests = {
+          cpu    = "0.25"
+          memory = "256M"
+        }
+      }
+    })
+  } : {}
 }
 
 # EKS Cluster
@@ -38,23 +56,23 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   cluster_version = var.kubernetes_version
 
   cluster_addons = merge(
-    var.cluster_addons_coredns ? {
-      coredns = {
-        most_recent = var.cluster_addons_most_recent
-      }
+    var.coredns ? {
+      coredns = merge(local.addon_defaults, local.coredns_addon_defaults)
     } : {},
-    {
-      eks-pod-identity-agent = {
-        most_recent = var.cluster_addons_most_recent
-      }
-      kube-proxy = {
-        most_recent = var.cluster_addons_most_recent
-      }
-      vpc-cni = {
-        most_recent              = var.cluster_addons_most_recent
-        service_account_role_arn = module.eks_vpc_cni_irsa.iam_role_arn
-      }
-    },
+    var.eks_pod_identity_agent ? {
+      "eks-pod-identity-agent" = local.addon_defaults
+    } : {},
+    var.kube_proxy ? {
+      "kube-proxy" = local.addon_defaults
+    } : {},
+    var.vpc_cni ? {
+      "vpc-cni" = merge(
+        local.addon_defaults,
+        {
+          service_account_role_arn = module.eks_vpc_cni_irsa[0].iam_role_arn
+        }
+      )
+    } : {},
     var.cluster_addons_overrides
   )
   cluster_addons_timeouts       = var.cluster_addons_timeouts

--- a/main.tf
+++ b/main.tf
@@ -75,10 +75,13 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
     } : {},
     var.cluster_addons_overrides
   )
-  cluster_addons_timeouts       = var.cluster_addons_timeouts
-  cluster_enabled_log_types     = var.cluster_enabled_log_types
-  create_cluster_security_group = var.create_cluster_security_group
-  create_node_security_group    = var.create_node_security_group
+  cluster_addons_timeouts   = var.cluster_addons_timeouts
+  cluster_enabled_log_types = var.cluster_enabled_log_types
+  # Fargate profiles use the cluster primary security group so these disabled
+  # for Karpenter as it expects only one security group to be tagged with
+  # `karpenter.sh/discovery`.
+  create_cluster_security_group = var.karpenter ? false : var.create_cluster_security_group
+  create_node_security_group    = var.karpenter ? false : var.create_node_security_group
 
   cluster_encryption_config = var.kms_manage ? {
     provider_key_arn = aws_kms_key.this[0].arn

--- a/main.tf
+++ b/main.tf
@@ -77,9 +77,8 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   )
   cluster_addons_timeouts   = var.cluster_addons_timeouts
   cluster_enabled_log_types = var.cluster_enabled_log_types
-  # Fargate profiles use the cluster primary security group so these disabled
-  # for Karpenter as it expects only one security group to be tagged with
-  # `karpenter.sh/discovery`.
+  # Karpenter as only one security group to be tagged with `karpenter.sh/discovery`,
+  # so disable additional cluster/node security groups automatically.
   create_cluster_security_group = var.karpenter ? false : var.create_cluster_security_group
   create_node_security_group    = var.karpenter ? false : var.create_node_security_group
 

--- a/variables.tf
+++ b/variables.tf
@@ -441,7 +441,7 @@ variable "nvidia_gpu_operator" {
 }
 
 variable "nvidia_gpu_operator_namespace" {
-  default     = "nvidia-gpu-operator"
+  default     = "gpu-operator"
   description = "Namespace that NVIDIA GPU Operator will use."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -214,6 +214,18 @@ variable "ebs_csi_driver_version" {
   type        = string
 }
 
+variable "ebs_storage_class_mount_options" {
+  default     = []
+  description = "EBS storage class mount options."
+  type        = list(string)
+}
+
+variable "ebs_storage_class_parameters" {
+  description = "EBS storage class parameters."
+  type        = any
+  default     = {}
+}
+
 variable "efs_csi_driver" {
   description = "Install and configure the EFS CSI storage driver."
   type        = bool
@@ -242,6 +254,23 @@ variable "efs_csi_driver_wait" {
   description = "Wait for the EFS CSI storage driver Helm chart install to complete."
   type        = bool
   default     = true
+}
+
+variable "efs_storage_class_mount_options" {
+  default     = []
+  description = "EFS storage class mount options."
+  type        = list(string)
+}
+
+variable "efs_storage_class_parameters" {
+  description = "EFS storage class parameters."
+  type        = any
+  default     = {
+    "provisioningMode" = "efs-ap"
+    "directoryPerms"   = "755"
+    "uid"              = "0"
+    "gid"              = "0"
+  }
 }
 
 variable "eks_managed_node_groups" {

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,12 @@ variable "create_node_security_group" {
   default     = true
 }
 
+variable "crossplane" {
+  description = "Indicates whether to install Crossplane."
+  type        = bool
+  default     = false
+}
+
 variable "crossplane_namespace" {
   default     = "crossplane-system"
   description = "Namespace that Crossplane will use."

--- a/variables.tf
+++ b/variables.tf
@@ -106,7 +106,7 @@ variable "coredns" {
 variable "coredns_fargate" {
   description = "Indicates whether to configure CoreDNS for running in Fargate."
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "create_node_security_group" {

--- a/variables.tf
+++ b/variables.tf
@@ -12,7 +12,7 @@ variable "cert_manager_namespace" {
 
 variable "cert_manager_values" {
   description = "Additional custom values for the cert-manager Helm chart."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -42,7 +42,7 @@ variable "cluster_addons_most_recent" {
 
 variable "cluster_addons_overrides" {
   description = "Override parameters for cluster addons."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -168,7 +168,7 @@ variable "ebs_csi_driver_namespace" {
 
 variable "ebs_csi_driver_values" {
   description = "Additional custom values for the EBS CSI Driver Helm chart."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -198,7 +198,7 @@ variable "efs_csi_driver_namespace" {
 
 variable "efs_csi_driver_values" {
   description = "Additional custom values for the EFS CSI Driver Helm chart."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -234,7 +234,7 @@ variable "fargate_profiles" {
 
 variable "fargate_profile_defaults" {
   description = "Map of Fargate Profile default configurations."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -264,7 +264,7 @@ variable "karpenter_namespace" {
 
 variable "karpenter_values" {
   description = "Additional custom values to use when installing the Karpenter Helm chart."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -324,7 +324,7 @@ variable "lb_controller_namespace" {
 
 variable "lb_controller_values" {
   description = "Additional custom values for the AWS Load Balancer Controller Helm chart."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -115,6 +115,36 @@ variable "create_node_security_group" {
   default     = true
 }
 
+variable "crossplane_namespace" {
+  default     = "crossplane-system"
+  description = "Namespace that Crossplane will use."
+  type        = string
+}
+
+variable "crossplane_policy_arns" {
+  default     = []
+  description = "Configure and install Crossplane with the given AWS IAM Policy ARNs."
+  type        = list(string)
+}
+
+variable "crossplane_values" {
+  description = "Additional custom values for the Crossplane Helm chart."
+  type        = any
+  default     = {}
+}
+
+variable "crossplane_wait" {
+  description = "Wait for the Crossplane Helm chart installation to complete."
+  type        = bool
+  default     = true
+}
+
+variable "crossplane_version" {
+  default     = "1.14.5"
+  description = "Version of Crossplane Helm chart to install."
+  type        = string
+}
+
 # The ECR repository is not the same for every region, in particular
 # those for govcloud:
 #   https://docs.aws.amazon.com/eks/latest/userguide/add-ons-images.html

--- a/variables.tf
+++ b/variables.tf
@@ -179,7 +179,7 @@ variable "ebs_csi_driver_wait" {
 }
 
 variable "ebs_csi_driver_version" {
-  default     = "2.25.0"
+  default     = "2.26.0"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }
@@ -257,7 +257,7 @@ variable "karpenter" {
 }
 
 variable "karpenter_namespace" {
-  default     = "karpenter"
+  default     = "kube-system"
   description = "Namespace that Karpenter will use."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -265,7 +265,7 @@ variable "efs_storage_class_mount_options" {
 variable "efs_storage_class_parameters" {
   description = "EFS storage class parameters."
   type        = any
-  default     = {
+  default = {
     "provisioningMode" = "efs-ap"
     "directoryPerms"   = "755"
     "uid"              = "0"

--- a/variables.tf
+++ b/variables.tf
@@ -34,12 +34,6 @@ variable "cert_manager_route53_zone_id" {
   type        = string
 }
 
-variable "cluster_addons_coredns" {
-  description = "Indicates whether to install the CoreDNS cluster addon."
-  type        = bool
-  default     = true
-}
-
 variable "cluster_addons_most_recent" {
   description = "Indicates whether to use the most recent version of cluster addons"
   type        = bool
@@ -99,6 +93,18 @@ variable "cluster_security_group_additional_rules" {
 
 variable "create_cluster_security_group" {
   description = "Determines if a security group is created for the cluster. Note: the EKS service creates a primary security group for the cluster by default"
+  type        = bool
+  default     = true
+}
+
+variable "coredns" {
+  description = "Indicates whether to install the CoreDNS cluster addon."
+  type        = bool
+  default     = true
+}
+
+variable "coredns_fargate" {
+  description = "Indicates whether to configure CoreDNS for running in Fargate."
   type        = bool
   default     = true
 }
@@ -214,6 +220,12 @@ variable "eks_managed_node_groups" {
   default     = {}
 }
 
+variable "eks_pod_identity_agent" {
+  description = "Indicates whether to install the eks-pod-identity-agent cluster addon."
+  type        = bool
+  default     = true
+}
+
 variable "fargate_profiles" {
   description = "Map of Fargate Profile definitions to create."
   type        = map(any)
@@ -282,6 +294,12 @@ variable "kms_key_deletion_window_in_days" {
 
 variable "kms_key_enable_default_policy" {
   description = "Specifies whether to enable the default key policy. Defaults to `true` to workaround EFS permissions."
+  type        = bool
+  default     = true
+}
+
+variable "kube_proxy" {
+  description = "Indicates whether to install the kube-proxy cluster addon."
   type        = bool
   default     = true
 }
@@ -405,4 +423,10 @@ variable "vpc_cidr" {
 variable "vpc_id" {
   description = "EKS Cluster VPC ID"
   type        = string
+}
+
+variable "vpc_cni" {
+  description = "Indicates whether to install the vpc-cni cluster addon."
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EBS CSI Controller v2.26.0](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/releases/tag/helm-chart-aws-ebs-csi-driver-2.26.0)

### New Features

* Add support for [Crossplane v1.14.5](https://github.com/crossplane/crossplane/releases/tag/v1.14.5)
* EFS CSI improvements: only need one role for the EFS CSI driver and tighten up its IRSA policy permissions to apply only to the EKS cluster's EFS filesystem.
* Add variables for toggling installation of the default add-ons: `coredns`, `eks_pod_identity_agent`, `kube_proxy`, `vpc_cni`.
* Add ability to customize EBS/EFS default storage class mount options and parameters with `{ebs,efs}_storage_class_{mount_options,parameters}` variables.
* Add `coredns_fargate` variable that will automatically configure the CoreDNS add-on for running in Fargate.

### Upgrade Notes

* Namespace for the NVIDIA GPU operator has changed to `gpu-operator`.
* Namespace for Karpenter has changed to `kube-system`, as now recommended for v0.33+.
* Now that `vpc-cni` plugin is optional, state variables will change forcing its recreation.
* EFS CSI roles will be deleted and consolidated into new `${cluster_name}-efs-csi-driver-role`.