### PR TITLE
Release 0.6.2

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -1,6 +1,6 @@
 ## cert-manager
 locals {
-  cert_manager_policy = var.cert_manager && length(var.cert_manager_route53_zone_id) > 0
+  cert_manager_policy = var.cert_manager && length(var.cert_manager_route53_zone_ids) > 0
 }
 
 module "cert_manager_irsa" {
@@ -35,7 +35,9 @@ data "aws_iam_policy_document" "cert_manager" {
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",
     ]
-    resources = ["arn:${local.aws_partition}:route53:::hostedzone/${var.cert_manager_route53_zone_id}"]
+    resources = [
+      for zone_id in var.cert_manager_route53_zone_ids : "arn:${local.aws_partition}:route53:::hostedzone/${zone_id}"
+    ]
   }
 }
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -40,7 +40,7 @@ resource "helm_release" "crossplane" {
     yamlencode({
       serviceAccount = {
         annotations = {
-          "eks.amazonaws.com/role-arn" = module.crossplane_irsa.iam_role_arn
+          "eks.amazonaws.com/role-arn" = module.crossplane_irsa[0].iam_role_arn
         }
       }
     }),

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -19,7 +19,7 @@ module "crossplane_irsa" {
 
 resource "aws_iam_role_policy_attachment" "crossplane" {
   count      = var.crossplane ? length(var.crossplane_policy_arns) : 0
-  role       = "${var.cluster_name}-crossplane-role"
+  role       = module.crossplane_irsa[0].iam_role_name
   policy_arn = var.crossplane_policy_arns[count.index]
   depends_on = [
     module.crossplane_irsa[0]
@@ -40,7 +40,7 @@ resource "helm_release" "crossplane" {
     yamlencode({
       serviceAccount = {
         annotations = {
-          "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-crossplane-role"
+          "eks.amazonaws.com/role-arn" = module.crossplane_irsa.iam_role_arn
         }
       }
     }),

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -38,13 +38,6 @@ resource "helm_release" "aws_ebs_csi_driver" {
             "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-ebs-csi-role"
           }
         }
-        topologySpreadConstraints = [
-          {
-            maxSkew           = 1
-            topologyKey       = "topology.kubernetes.io/zone"
-            whenUnsatisfiable = "ScheduleAnyway"
-          }
-        ]
       }
       image = {
         repository = "${var.csi_ecr_repository_id}.dkr.ecr.${local.aws_region}.amazonaws.com/eks/aws-ebs-csi-driver"

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -31,16 +31,23 @@ resource "helm_release" "aws_ebs_csi_driver" {
 
   values = [
     yamlencode({
-      "controller" = {
-        "extraVolumeTags" = var.tags
-        "serviceAccount" = {
-          "annotations" = {
+      controller = {
+        extraVolumeTags = var.tags
+        serviceAccount = {
+          annotations = {
             "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-ebs-csi-role"
           }
         }
+        topologySpreadConstraints = [
+          {
+            maxSkew           = 1
+            topologyKey       = "topology.kubernetes.io/zone"
+            whenUnsatisfiable = "ScheduleAnyway"
+          }
+        ]
       }
-      "image" = {
-        "repository" = "${var.csi_ecr_repository_id}.dkr.ecr.${local.aws_region}.amazonaws.com/eks/aws-ebs-csi-driver"
+      image = {
+        repository = "${var.csi_ecr_repository_id}.dkr.ecr.${local.aws_region}.amazonaws.com/eks/aws-ebs-csi-driver"
       }
     }),
     yamlencode(var.ebs_csi_driver_values),

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -43,7 +43,7 @@ resource "kubernetes_storage_class" "eks_ebs_storage_class" {
   volume_binding_mode = "WaitForFirstConsumer"
 
   depends_on = [
-    helm_release.aws_ebs_csi_driver[0],
+    module.eks,
   ]
 }
 

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -69,7 +69,7 @@ resource "kubernetes_storage_class" "eks_ebs_storage_class" {
   parameters = merge(
     var.ebs_storage_class_parameters,
     {
-      kmsKeyId = var.kms_manage ? aws_kms_key.this[0].arn : module.eks.kms_key_arn
+      kmsKeyId = var.kms_manage ? aws_kms_key.this[0].id : module.eks.kms_key_id
     }
   )
   storage_provisioner = "ebs.csi.aws.com"

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -1,7 +1,7 @@
 ## EBS CSI Storage Driver
 
 # Allow PVCs backed by EBS
-module "eks_ebs_csi_irsa" {
+module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.33.0"

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -142,26 +142,6 @@ resource "helm_release" "aws_efs_csi_driver" {
     yamlencode({
       controller = {
         # Use `podAntiAffinity` since the EFS chart doesn't support `topologySpreadConstraints`.
-        affinity = {
-          podAntiAffinity = {
-            requiredDuringSchedulingIgnoredDuringExecution = [
-              {
-                labelSelector = {
-                  matchExpressions = [
-                    {
-                      key      = "app"
-                      operator = "In"
-                      values = [
-                        "efs-csi-controller"
-                      ]
-                    }
-                  ]
-                }
-                topologyKey = "topology.kubernetes.io/zone"
-              }
-            ]
-          }
-        }
         serviceAccount = {
           annotations = {
             "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-efs-csi-driver-role"

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -121,7 +121,7 @@ resource "aws_iam_policy" "eks_efs_csi_driver" {
 
 resource "aws_iam_role_policy_attachment" "eks_efs_csi_driver" {
   count      = var.efs_csi_driver ? 1 : 0
-  role       = "${var.cluster_name}-efs-csi-driver-role"
+  role       = module.eks_efs_csi_driver_irsa[0].iam_role_name
   policy_arn = aws_iam_policy.eks_efs_csi_driver[0].arn
   depends_on = [
     module.eks_efs_csi_driver_irsa[0]
@@ -143,7 +143,7 @@ resource "helm_release" "aws_efs_csi_driver" {
       controller = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-efs-csi-driver-role"
+            "eks.amazonaws.com/role-arn" = module.eks_efs_csi_driver_irsa[0].iam_role_arn
           }
         }
         tags = local.tags_noname
@@ -154,7 +154,7 @@ resource "helm_release" "aws_efs_csi_driver" {
       node = {
         serviceAccount = {
           annotations = {
-            "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-efs-csi-driver-role"
+            "eks.amazonaws.com/role-arn" = module.eks_efs_csi_driver_irsa[0].iam_role_arn
           }
         }
       }

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -146,7 +146,7 @@ resource "helm_release" "aws_efs_csi_driver" {
             "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-efs-csi-driver-role"
           }
         }
-        tags = var.tags
+        tags = local.tags_noname
       }
       image = {
         repository = "${var.csi_ecr_repository_id}.dkr.ecr.${local.aws_region}.amazonaws.com/eks/aws-efs-csi-driver"

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -141,7 +141,6 @@ resource "helm_release" "aws_efs_csi_driver" {
   values = [
     yamlencode({
       controller = {
-        # Use `podAntiAffinity` since the EFS chart doesn't support `topologySpreadConstraints`.
         serviceAccount = {
           annotations = {
             "eks.amazonaws.com/role-arn" = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-efs-csi-driver-role"

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -6,7 +6,7 @@ module "karpenter" {
   # source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   # version = "20.x.x"
   cluster_name                    = var.cluster_name
-  iam_role_additional_policies    = var.karpenter_iam_role_additional_policies
+  iam_role_additional_policies    = var.iam_role_additional_policies
   iam_role_attach_cni_policy      = var.iam_role_attach_cni_policy
   irsa_namespace_service_accounts = ["${var.karpenter_namespace}:karpenter"]
   irsa_oidc_provider_arn          = module.eks.oidc_provider_arn

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -6,6 +6,7 @@ module "karpenter" {
   # source  = "terraform-aws-modules/eks/aws//modules/karpenter"
   # version = "20.x.x"
   cluster_name                    = var.cluster_name
+  iam_role_additional_policies    = var.karpenter_iam_role_additional_policies
   iam_role_attach_cni_policy      = var.iam_role_attach_cni_policy
   irsa_namespace_service_accounts = ["${var.karpenter_namespace}:karpenter"]
   irsa_oidc_provider_arn          = module.eks.oidc_provider_arn

--- a/lb.tf
+++ b/lb.tf
@@ -41,13 +41,6 @@ resource "helm_release" "aws_lb_controller" {
         }
         name = "aws-load-balancer-controller"
       }
-      topologySpreadConstraints = [
-        {
-          maxSkew           = 1
-          topologyKey       = "topology.kubernetes.io/zone"
-          whenUnsatisfiable = "ScheduleAnyway"
-        }
-      ]
       vpcId = var.vpc_id
     }),
     yamlencode(var.lb_controller_values),

--- a/lb.tf
+++ b/lb.tf
@@ -31,17 +31,24 @@ resource "helm_release" "aws_lb_controller" {
 
   values = [
     yamlencode({
-      "clusterName" = var.cluster_name
-      "defaultTags" = var.tags
-      "region"      = local.aws_region
-      "serviceAccount" = {
-        "annotations" = {
+      clusterName = var.cluster_name
+      defaultTags = var.tags
+      region      = local.aws_region
+      serviceAccount = {
+        annotations = {
           "eks.amazonaws.com/role-arn"               = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-lb-role"
           "eks.amazonaws.com/sts-regional-endpoints" = "true"
         }
-        "name" = "aws-load-balancer-controller"
+        name = "aws-load-balancer-controller"
       }
-      "vpcId" = var.vpc_id
+      topologySpreadConstraints = [
+        {
+          maxSkew           = 1
+          topologyKey       = "topology.kubernetes.io/zone"
+          whenUnsatisfiable = "ScheduleAnyway"
+        }
+      ]
+      vpcId = var.vpc_id
     }),
     yamlencode(var.lb_controller_values),
   ]

--- a/lb.tf
+++ b/lb.tf
@@ -36,7 +36,7 @@ resource "helm_release" "aws_lb_controller" {
       region      = local.aws_region
       serviceAccount = {
         annotations = {
-          "eks.amazonaws.com/role-arn"               = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${var.cluster_name}-lb-role"
+          "eks.amazonaws.com/role-arn"               = module.eks_lb_irsa[0].iam_role_arn
           "eks.amazonaws.com/sts-regional-endpoints" = "true"
         }
         name = "aws-load-balancer-controller"

--- a/main.tf
+++ b/main.tf
@@ -57,6 +57,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
         },
         var.ebs_csi_driver_options
       )
+      "snapshot-controller" = local.addon_defaults
     } : {},
     var.coredns ? {
       coredns = merge(local.addon_defaults, var.coredns_options)

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,9 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
       "vpc-cni" = merge(
         local.addon_defaults,
         {
+          configuration_values = jsonencode({
+            enableNetworkPolicy = "true"
+          })
           service_account_role_arn = module.eks_vpc_cni_irsa[0].iam_role_arn
         },
         var.vpc_cni_options

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,15 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
         var.ebs_csi_driver_options
       )
     } : {},
+    var.s3_csi_driver ? {
+      "aws-mountpoint-s3-csi-driver" = merge(
+        local.addon_defaults,
+        {
+          service_account_role_arn = module.eks_s3_csi_irsa[0].iam_role_arn
+        },
+        var.s3_csi_driver_options
+      )
+    } : {},
     var.coredns ? {
       coredns = merge(local.addon_defaults, var.coredns_options)
     } : {},

--- a/main.tf
+++ b/main.tf
@@ -30,6 +30,10 @@ locals {
     local.aws_auth_karpenter_roles,
     var.aws_auth_roles
   )
+  tags_noname = {
+    for key, value in var.tags : key => value
+    if key != "Name"
+  }
 }
 
 # EKS Cluster
@@ -47,10 +51,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
         {
           configuration_values = jsonencode({
             controller = {
-              extraVolumeTags = {
-                for key, value in var.tags : key => value
-                if key != "Name"
-              }
+              extraVolumeTags = local.tags_noname
             }
           })
           service_account_role_arn = module.eks_ebs_csi_irsa[0].iam_role_arn

--- a/main.tf
+++ b/main.tf
@@ -23,7 +23,7 @@ locals {
     [
       for role in var.system_masters_roles : {
         rolearn  = "arn:${local.aws_partition}:iam::${local.aws_account_id}:role/${role}"
-        username = role
+        username = "${role}:{{SessionName}}"
         groups   = ["system:masters"]
       }
     ],

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
       "aws-mountpoint-s3-csi-driver" = merge(
         local.addon_defaults,
         {
-          service_account_role_arn = module.eks_s3_csi_irsa[0].iam_role_arn
+          service_account_role_arn = module.eks_s3_csi_driver_irsa[0].iam_role_arn
         },
         var.s3_csi_driver_options
       )

--- a/main.tf
+++ b/main.tf
@@ -58,7 +58,6 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
         },
         var.ebs_csi_driver_options
       )
-      "snapshot-controller" = local.addon_defaults
     } : {},
     var.coredns ? {
       coredns = merge(local.addon_defaults, var.coredns_options)
@@ -68,6 +67,9 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
     } : {},
     var.kube_proxy ? {
       "kube-proxy" = merge(local.addon_defaults, var.kube_proxy_options)
+    } : {},
+    var.snapshot_controller ? {
+      "snapshot-controller" = merge(local.addon_defaults, var.snapshot_controller_options)
     } : {},
     var.vpc_cni ? {
       "vpc-cni" = merge(

--- a/main.tf
+++ b/main.tf
@@ -46,9 +46,11 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
         local.addon_defaults,
         {
           configuration_values = jsonencode({
-            extraVolumeTags = {
-              for key, value in var.tags : key => value
-              if key != "Name"
+            controller = {
+              extraVolumeTags = {
+                for key, value in var.tags : key => value
+                if key != "Name"
+              }
             }
           })
           service_account_role_arn = module.eks_ebs_csi_irsa[0].iam_role_arn

--- a/main.tf
+++ b/main.tf
@@ -45,6 +45,12 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
       "aws-ebs-csi-driver" = merge(
         local.addon_defaults,
         {
+          configuration_values = jsonencode({
+            extraVolumeTags = {
+              for key, value in var.tags : key => value
+              if key != "Name"
+            }
+          })
           service_account_role_arn = module.eks_ebs_csi_irsa[0].iam_role_arn
         },
         var.ebs_csi_driver_options

--- a/main.tf
+++ b/main.tf
@@ -41,6 +41,15 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   cluster_version = var.kubernetes_version
 
   cluster_addons = merge(
+    var.ebs_csi_driver ? {
+      "aws-ebs-csi-driver" = merge(
+        local.addon_defaults,
+        {
+          service_account_role_arn = module.eks_ebs_csi_irsa[0].iam_role_arn
+        },
+        var.ebs_csi_driver_options
+      )
+    } : {},
     var.coredns ? {
       coredns = merge(local.addon_defaults, var.coredns_options)
     } : {},

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,13 @@ locals {
           memory = "256M"
         }
       }
+      topologySpreadConstraints = [
+        {
+          maxSkew           = 1
+          topologyKey       = "topology.kubernetes.io/zone"
+          whenUnsatisfiable = "ScheduleAnyway"
+        }
+      ]
     })
   } : {}
 }

--- a/main.tf
+++ b/main.tf
@@ -123,13 +123,14 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   node_security_group_additional_rules = var.node_security_group_additional_rules
 
   eks_managed_node_group_defaults = {
-    ami_type                   = var.default_ami_type
-    capacity_type              = var.default_capacity_type
-    desired_size               = var.default_desired_size
-    ebs_optimized              = true
-    iam_role_attach_cni_policy = var.iam_role_attach_cni_policy
-    max_size                   = var.default_max_size
-    min_size                   = var.default_min_size
+    ami_type                     = var.default_ami_type
+    capacity_type                = var.default_capacity_type
+    desired_size                 = var.default_desired_size
+    ebs_optimized                = true
+    iam_role_additional_policies = var.iam_role_additional_policies
+    iam_role_attach_cni_policy   = var.iam_role_attach_cni_policy
+    max_size                     = var.default_max_size
+    min_size                     = var.default_min_size
   }
   eks_managed_node_groups = var.eks_managed_node_groups
 

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
               extraVolumeTags = local.tags_noname
             }
           })
-          service_account_role_arn = module.eks_ebs_csi_irsa[0].iam_role_arn
+          service_account_role_arn = module.eks_ebs_csi_driver_irsa[0].iam_role_arn
         },
         var.ebs_csi_driver_options
       )

--- a/nvidia.tf
+++ b/nvidia.tf
@@ -8,6 +8,7 @@ resource "helm_release" "nvidia_gpu_operator" {
   namespace        = var.nvidia_gpu_operator_namespace
   repository       = "https://helm.ngc.nvidia.com/nvidia"
   wait             = var.nvidia_gpu_operator_wait
+  values           = [yamlencode(var.nvidia_gpu_operator_values)]
   version          = "v${var.nvidia_gpu_operator_version}"
 
   depends_on = [

--- a/outputs.tf
+++ b/outputs.tf
@@ -75,10 +75,10 @@ output "oidc_provider_arn" {
 
 output "s3_csi_driver_role_arn" {
   description = "The S3 CSI Storage Driver IRSA role Amazon Resource Name (ARN)"
-  value       = var.s3_csi_driver ? eks_s3_csi_driver_irsa[0].iam_role_arn : null
+  value       = var.s3_csi_driver ? module.eks_s3_csi_driver_irsa[0].iam_role_arn : null
 }
 
 output "s3_csi_driver_role_name" {
   description = "The S3 CSI Storage Driver IRSA role name"
-  value       = var.s3_csi_driver ? eks_s3_csi_driver_irsa[0].iam_role_name : null
+  value       = var.s3_csi_driver ? module.eks_s3_csi_driver_irsa[0].iam_role_name : null
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,13 @@
+output "cert_manager_role_arn" {
+  description = "The cert-manager IRSA role Amazon Resource Name (ARN)"
+  value       = var.cert_manager ? module.cert_manager_irsa[0].iam_role_arn : null
+}
+
+output "cert_manager_role_name" {
+  description = "The cert-manager IRSA role name"
+  value       = var.cert_manager ? module.cert_manager_irsa[0].iam_role_name : null
+}
+
 output "cluster_certificate_authority_data" {
   description = "Base64 encoded certificate data required to communicate with the cluster"
   value       = module.eks.cluster_certificate_authority_data
@@ -16,6 +26,36 @@ output "cluster_oidc_issuer_url" {
 output "cluster_primary_security_group_id" {
   description = "Cluster security group that was created by Amazon EKS for the cluster. Managed node groups use this security group for control-plane-to-data-plane communication. Referred to as 'Cluster security group' in the EKS console"
   value       = module.eks.cluster_primary_security_group_id
+}
+
+output "crossplane_role_arn" {
+  description = "The Crossplane IRSA role Amazon Resource Name (ARN)"
+  value       = var.crossplane ? module.crossplane_irsa[0].iam_role_arn : null
+}
+
+output "crossplane_role_name" {
+  description = "The Crossplane IRSA role name"
+  value       = var.crossplane ? module.crossplane_irsa[0].iam_role_name : null
+}
+
+output "ebs_csi_driver_role_arn" {
+  description = "The EBS CSI Storage Driver IRSA role Amazon Resource Name (ARN)"
+  value       = var.ebs_csi_driver ? module.eks_ebs_csi_irsa[0].iam_role_arn : null
+}
+
+output "ebs_csi_driver_role_name" {
+  description = "The EBS CSI Storage Driver IRSA role name"
+  value       = var.ebs_csi_driver ? module.eks_ebs_csi_irsa[0].iam_role_name : null
+}
+
+output "efs_csi_driver_role_arn" {
+  description = "The EFS CSI Storage Driver IRSA role Amazon Resource Name (ARN)"
+  value       = var.efs_csi_driver ? module.eks_efs_csi_driver_irsa[0].iam_role_arn : null
+}
+
+output "efs_csi_driver_role_name" {
+  description = "The EFS CSI Storage Driver IRSA role name"
+  value       = var.efs_csi_driver ? module.eks_efs_csi_driver_irsa[0].iam_role_name : null
 }
 
 output "eks_managed_node_groups" {
@@ -51,6 +91,16 @@ output "kms_key_arn" {
 output "kms_key_id" {
   description = "The globally unique identifier for the EKS KMS cluster key"
   value       = var.kms_manage ? aws_kms_key.this[0].id : module.eks.kms_key_id
+}
+
+output "lb_controller_role_arn" {
+  description = "The AWS Load Balancer Controller IRSA role Amazon Resource Name (ARN)"
+  value       = var.lb_controller ? module.eks_lb_irsa[0].iam_role_arn : null
+}
+
+output "lb_controller_role_name" {
+  description = "The AWS Load Balancer Controller IRSA role name"
+  value       = var.lb_controller ? module.eks_lb_irsa[0].iam_role_name : null
 }
 
 output "node_security_group_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -72,3 +72,13 @@ output "oidc_provider_arn" {
   description = "The ARN of the OIDC Provider if `enable_irsa = true`"
   value       = module.eks.oidc_provider_arn
 }
+
+output "s3_csi_driver_role_arn" {
+  description = "The S3 CSI Storage Driver IRSA role Amazon Resource Name (ARN)"
+  value       = var.s3_csi_driver ? eks_s3_csi_driver_irsa[0].iam_role_arn : null
+}
+
+output "s3_csi_driver_role_name" {
+  description = "The S3 CSI Storage Driver IRSA role name"
+  value       = var.s3_csi_driver ? eks_s3_csi_driver_irsa[0].iam_role_name : null
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -40,12 +40,12 @@ output "crossplane_role_name" {
 
 output "ebs_csi_driver_role_arn" {
   description = "The EBS CSI Storage Driver IRSA role Amazon Resource Name (ARN)"
-  value       = var.ebs_csi_driver ? module.eks_ebs_csi_irsa[0].iam_role_arn : null
+  value       = var.ebs_csi_driver ? module.eks_ebs_csi_driver_irsa[0].iam_role_arn : null
 }
 
 output "ebs_csi_driver_role_name" {
   description = "The EBS CSI Storage Driver IRSA role name"
-  value       = var.ebs_csi_driver ? module.eks_ebs_csi_irsa[0].iam_role_name : null
+  value       = var.ebs_csi_driver ? module.eks_ebs_csi_driver_irsa[0].iam_role_name : null
 }
 
 output "efs_csi_driver_role_arn" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -48,6 +48,11 @@ output "kms_key_arn" {
   value       = var.kms_manage ? aws_kms_key.this[0].arn : module.eks.kms_key_arn
 }
 
+output "kms_key_id" {
+  description = "The globally unique identifier for the EKS KMS cluster key"
+  value       = var.kms_manage ? aws_kms_key.this[0].id : module.eks.kms_key_id
+}
+
 output "node_security_group_arn" {
   description = "ARN of the EKS node shared security group"
   value       = module.eks.node_security_group_arn

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -1,5 +1,5 @@
 locals {
-  s3_csi_driver_policy = var.s3_csi_driver && length(var.s3_csi_driver_bucket_name) > 0
+  s3_csi_driver_policy = var.s3_csi_driver && length(var.s3_csi_driver_bucket_names) > 0
 }
 
 module "eks_s3_csi_driver_irsa" {
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "eks_s3_csi_driver" {
       "s3:ListBucket"
     ]
     resources = [
-      "arn:${local.aws_partition}:s3:::${var.s3_csi_driver_bucket_name}"
+      for bucket_name in var.s3_csi_driver_bucket_names : "arn:${local.aws_partition}:s3:::${bucket_name}"
     ]
   }
 
@@ -43,7 +43,7 @@ data "aws_iam_policy_document" "eks_s3_csi_driver" {
       "s3:DeleteObject"
     ]
     resources = [
-      "arn:${local.aws_partition}:s3:::${var.s3_csi_driver_bucket_name}/*"
+      for bucket_name in var.s3_csi_driver_bucket_names : "arn:${local.aws_partition}:s3:::${bucket_name}/*"
     ]
   }
 }

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -1,0 +1,67 @@
+locals {
+  s3_csi_driver_policy    = len(var.s3_csi_driver_bucket_name) > 0
+  s3_csi_driver_role_name = "${var.cluster_name}-s3-csi-driver-role"
+}
+
+module "eks_s3_csi_driver_irsa" {
+  count = var.s3_csi_driver ? 1 : 0
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.33.0"
+
+  role_name = local.s3_csi_driver_role_name
+
+  oidc_providers = {
+    main = {
+      provider_arn = module.eks.oidc_provider_arn
+      namespace_service_accounts = [
+        "kube-system:mountpoint-s3-csi-controller-sa",
+      ]
+    }
+  }
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "eks_s3_csi_driver" {
+  count = local.s3_csi_driver_policy ? 1 : 0
+
+  statement {
+    sid = "MountpointFullBucketAccess"
+    actions = [
+      "s3:ListBucket"
+    ]
+    resources = [
+      "arn:${local.aws_partition}:s3:::${var.s3_csi_driver_bucket_name}"
+    ]
+  }
+
+  statement {
+    sid = "MountpointFullObjectAccess"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject"
+    ]
+    resources = [
+      "arn:${local.aws_partition}:s3:::${var.s3_csi_driver_bucket_name}/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "eks_s3_csi_driver" {
+  count       = local.s3_csi_driver_policy ? 1 : 0
+  name        = "AmazonEKS_S3_CSI_Policy-${var.cluster_name}"
+  description = "Provides permissions to manage S3-backed volumes via the container storage interface driver"
+  policy      = data.aws_iam_policy_document.eks_s3_csi_driver[0].json
+  tags        = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "s3_efs_csi_driver" {
+  count      = local.s3_csi_driver_policy ? 1 : 0
+  role       = module.eks_s3_csi_driver_irsa[0].iam_role_name
+  policy_arn = aws_iam_policy.eks_s3_csi_driver[0].arn
+  depends_on = [
+    module.eks_s3_csi_driver_irsa[0]
+  ]
+}

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -1,5 +1,5 @@
 locals {
-  s3_csi_driver_policy    = len(var.s3_csi_driver_bucket_name) > 0
+  s3_csi_driver_policy    = length(var.s3_csi_driver_bucket_name) > 0
   s3_csi_driver_role_name = "${var.cluster_name}-s3-csi-driver-role"
 }
 

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -1,6 +1,5 @@
 locals {
-  s3_csi_driver_policy    = length(var.s3_csi_driver_bucket_name) > 0
-  s3_csi_driver_role_name = "${var.cluster_name}-s3-csi-driver-role"
+  s3_csi_driver_policy = var.s3_csi_driver && length(var.s3_csi_driver_bucket_name) > 0
 }
 
 module "eks_s3_csi_driver_irsa" {
@@ -9,7 +8,7 @@ module "eks_s3_csi_driver_irsa" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "5.33.0"
 
-  role_name = local.s3_csi_driver_role_name
+  role_name = "${var.cluster_name}-s3-csi-driver-role"
 
   oidc_providers = {
     main = {

--- a/variables.tf
+++ b/variables.tf
@@ -468,6 +468,18 @@ variable "public_subnets" {
   type        = list(any)
 }
 
+variable "snapshot_controller" {
+  description = "Indicates whether to install the snapshot-controller cluster addon."
+  type        = bool
+  default     = true
+}
+
+variable "snapshot_controller_options" {
+  description = "Custom options for the snapshot-controller addon."
+  type        = any
+  default     = {}
+}
+
 variable "system_masters_roles" {
   default     = ["PowerUsers"]
   description = "Roles from the AWS account allowed system:masters to the EKS cluster."

--- a/variables.tf
+++ b/variables.tf
@@ -56,9 +56,9 @@ variable "cluster_addons_timeouts" {
   description = "Create, update, and delete timeout configurations for the cluster addons"
   type        = map(string)
   default = {
-    create = "25m"
+    create = "10m"
     delete = "10m"
-    update = "15m"
+    update = "10m"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -309,16 +309,16 @@ variable "iam_role_attach_cni_policy" {
   type        = bool
 }
 
+variable "iam_role_additional_policies" {
+  description = "Additional policies to be attached to EKS Node groups"
+  type        = map(string)
+  default     = {}
+}
+
 variable "karpenter" {
   description = "Whether to use Karpenter with the EKS cluster."
   type        = bool
   default     = false
-}
-
-variable "karpenter_iam_role_additional_policies" {
-  description = "Additional IAM policies to be attached to Karpenter's role."
-  type        = map(string)
-  default     = {}
 }
 
 variable "karpenter_namespace" {

--- a/variables.tf
+++ b/variables.tf
@@ -504,14 +504,14 @@ variable "s3_csi_driver" {
   default     = false
 }
 
-variable "s3_csi_driver_bucket_name" {
-  description = "The bucket name to use with the S3 CSI storage driver addon."
-  type        = string
-  default     = ""
+variable "s3_csi_driver_bucket_names" {
+  description = "The bucket names that the S3 CSI storage driver addon has permission to use."
+  type        = list(string)
+  default     = []
 }
 
 variable "s3_csi_driver_options" {
-  description = "Additional custom values for the S3 CSI storage driver addon"
+  description = "Additional custom values for the S3 CSI storage driver addon."
   type        = any
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -103,10 +103,10 @@ variable "coredns" {
   default     = true
 }
 
-variable "coredns_fargate" {
-  description = "Indicates whether to configure CoreDNS for running in Fargate."
-  type        = bool
-  default     = false
+variable "coredns_options" {
+  description = "Custom options for the CoreDNS addon."
+  type        = any
+  default     = {}
 }
 
 variable "create_node_security_group" {
@@ -291,6 +291,12 @@ variable "eks_pod_identity_agent" {
   default     = true
 }
 
+variable "eks_pod_identity_options" {
+  description = "Custom options for the eks-pod-identity-agent addon."
+  type        = any
+  default     = {}
+}
+
 variable "fargate_profiles" {
   description = "Map of Fargate Profile definitions to create."
   type        = map(any)
@@ -367,6 +373,12 @@ variable "kube_proxy" {
   description = "Indicates whether to install the kube-proxy cluster addon."
   type        = bool
   default     = true
+}
+
+variable "kube_proxy_options" {
+  description = "Custom options for the kube-proxy addon."
+  type        = any
+  default     = {}
 }
 
 variable "kubernetes_version" {
@@ -500,4 +512,10 @@ variable "vpc_cni" {
   description = "Indicates whether to install the vpc-cni cluster addon."
   type        = bool
   default     = true
+}
+
+variable "vpc_cni_options" {
+  description = "Custom options for the vpc-cni addon."
+  type        = any
+  default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -446,6 +446,12 @@ variable "nvidia_gpu_operator_namespace" {
   type        = string
 }
 
+variable "nvidia_gpu_operator_values" {
+  description = "Additional custom values for the NVIDIA GPU Operator Helm chart."
+  type        = any
+  default     = {}
+}
+
 variable "nvidia_gpu_operator_version" {
   default     = "23.9.1"
   description = "Version of the NVIDIA GPU Operator Helm chart to install."

--- a/variables.tf
+++ b/variables.tf
@@ -196,28 +196,10 @@ variable "ebs_csi_driver" {
   default     = true
 }
 
-variable "ebs_csi_driver_namespace" {
-  default     = "kube-system"
-  description = "Namespace that EBS CSI storage driver will use."
-  type        = string
-}
-
-variable "ebs_csi_driver_values" {
+variable "ebs_csi_driver_options" {
   description = "Additional custom values for the EBS CSI Driver Helm chart."
   type        = any
   default     = {}
-}
-
-variable "ebs_csi_driver_wait" {
-  description = "Wait for the EBS CSI storage driver Helm chart install to complete."
-  type        = bool
-  default     = true
-}
-
-variable "ebs_csi_driver_version" {
-  default     = "2.26.0"
-  description = "Version of the EFS CSI storage driver to install."
-  type        = string
 }
 
 variable "ebs_storage_class_mount_options" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_auth_roles" {
   description = "List of additional role maps to add to the aws-auth configmap, use with caution."
-  type        = list(map)
+  type        = list(map(any))
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -315,6 +315,12 @@ variable "karpenter" {
   default     = false
 }
 
+variable "karpenter_iam_role_additional_policies" {
+  description = "Additional IAM policies to be attached to Karpenter's role."
+  type        = map(string)
+  default     = {}
+}
+
 variable "karpenter_namespace" {
   default     = "kube-system"
   description = "Namespace that Karpenter will use."

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_auth_roles" {
   description = "List of additional role maps to add to the aws-auth configmap, use with caution."
-  type        = list(map(any))
+  type        = list(any)
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -291,7 +291,7 @@ variable "eks_pod_identity_agent" {
   default     = true
 }
 
-variable "eks_pod_identity_options" {
+variable "eks_pod_identity_agent_options" {
   description = "Custom options for the eks-pod-identity-agent addon."
   type        = any
   default     = {}

--- a/variables.tf
+++ b/variables.tf
@@ -197,7 +197,7 @@ variable "ebs_csi_driver" {
 }
 
 variable "ebs_csi_driver_options" {
-  description = "Additional custom values for the EBS CSI Driver Helm chart."
+  description = "Additional custom values for the EBS CSI Driver addon."
   type        = any
   default     = {}
 }
@@ -484,6 +484,24 @@ variable "system_masters_roles" {
   default     = ["PowerUsers"]
   description = "Roles from the AWS account allowed system:masters to the EKS cluster."
   type        = list(string)
+}
+
+variable "s3_csi_driver" {
+  description = "Install and configure the S3 CSI storage driver addon."
+  type        = bool
+  default     = false
+}
+
+variable "s3_csi_driver_bucket_name" {
+  description = "The bucket name to use with the S3 CSI storage driver addon."
+  type        = string
+  default     = ""
+}
+
+variable "s3_csi_driver_options" {
+  description = "Additional custom values for the S3 CSI storage driver addon"
+  type        = any
+  default     = {}
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -16,10 +16,10 @@ variable "cert_manager_namespace" {
   type        = string
 }
 
-variable "cert_manager_route53_zone_id" {
-  default     = ""
-  description = "Configure cert-manager to issue certificates for this Route53 DNS Zone when provided"
-  type        = string
+variable "cert_manager_route53_zone_ids" {
+  default     = []
+  description = "Configure cert-manager to issue certificates for these Route53 DNS Zone IDs when provided."
+  type        = list(string)
 }
 
 variable "cert_manager_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -4,9 +4,21 @@ variable "aws_auth_roles" {
   default     = []
 }
 
+variable "cert_manager" {
+  description = "Install the cert-manager Helm chart when set."
+  type        = bool
+  default     = false
+}
+
 variable "cert_manager_namespace" {
   default     = "cert-manager"
   description = "Namespace that cert-manager will use."
+  type        = string
+}
+
+variable "cert_manager_route53_zone_id" {
+  default     = ""
+  description = "Configure cert-manager to issue certificates for this Route53 DNS Zone when provided"
   type        = string
 }
 
@@ -16,22 +28,16 @@ variable "cert_manager_values" {
   default     = {}
 }
 
-variable "cert_manager_wait" {
-  description = "Wait for the cert-manager Helm chart installation to complete."
-  type        = bool
-  default     = true
-}
-
 variable "cert_manager_version" {
   default     = "1.13.3"
   description = "Version of cert-manager to install."
   type        = string
 }
 
-variable "cert_manager_route53_zone_id" {
-  default     = ""
-  description = "Configure cert-manager to issue certificates for this Route53 DNS Zone when provided"
-  type        = string
+variable "cert_manager_wait" {
+  description = "Wait for the cert-manager Helm chart installation to complete."
+  type        = bool
+  default     = true
 }
 
 variable "cluster_addons_most_recent" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,6 @@
 variable "aws_auth_roles" {
-  description = "List of role maps to add to the aws-auth configmap"
-  type        = list(any)
+  description = "List of additional role maps to add to the aws-auth configmap, use with caution."
+  type        = list(map)
   default     = []
 }
 


### PR DESCRIPTION
### New Features

* Add [Mountpoint for S3 CSI Driver](https://github.com/awslabs/mountpoint-s3-csi-driver) support, via `aws-mountpoint-s3-csi-driver` addon, with the `s3_csi_driver`, `s3_csi_driver_bucket_names`, and s3_csi_driver_bucket_options` variables.
* Add `snapshot-controller` addon support with `snapshot_controller` and `snapshot_controller_options` variables.  Installed by default, this supports the EBS CSI driver in managing snapshots.
* Add `iam_role_additional_policies` variable to attach additional policies to the EKS Node group, e.g.:

  ```terraform
  # Allow SSM access to nodes.
  iam_role_additional_policies = {
    AmazonSSMManagedInstanceCore = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
  }
  ```
  
* Add variables for customizing addon versions: `coredns_options`, `ebs_csi_driver_options`, `eks_pod_identity_agent_options`, `kube_proxy_options`, `vpc_cni_options`.
* Add output variables for IRSA role names/ARNs and use variables for them instead of generated strings.
* Add missing `nvidia_gpu_operator_values` variable as is available for other Helm-managed features.

### Changed Features

* EBS CSI Driver
  * Now installed via the `aws-ebs-csi-driver` addon, with version updates handled by AWS.
  * Configure default `ebs-sc` storage class to encrypt volumes with cluster KMS key id by default.
* `vpc-cni` configure by default to enable network policies
* `cert-manager` installation requires the new `cert_manager` variable to be set to `true` and multiple Route53 zones are supported in a `cert_manager_route53_zone_ids` list.
* `aws-auth` configmap updates: include `{{SessionName}}` in username for `system:masters` group; use `aws-eks` variable for Karpenter's `aws-auth` entries.

### Backwards-incompatible Changes

* EBS CSI Driver
  * Uninstall the existing controller before installing the addon:

    ```
    helm --namespace kube-system uninstall aws-ebs-csi-driver
    ```
    
  * The `ebs_csi_driver_{namespace,values,wait,version}` variables have been removed now that it's managed via addon.
  * The Terraform variables for the EBS CSI IRSA role have changed; **errors may occur when the role resource is recreated, re-running Terraform/OpenTofu will fix**, e.g. `tofo apply`.
* `cert-manager`: must set `cert_manager` variable to enable and the `cert_manager_route53_zone_id` variable has been renamed to `cert_manager_route53_zone_ids` so that it's possible to support issuing certificates on multiple Route53 domains.
* The `coredns_fargate` option has been removed, any Fargate customizations can be done with the `coredns_options` variable instead.
