### PR TITLE
Release 0.6.4

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -93,7 +93,7 @@ variable "cluster_name" {
 
 variable "cluster_security_group_additional_rules" {
   description = "Additional security group rules to add to the cluster security group created."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -269,7 +269,7 @@ variable "efs_storage_class_parameters" {
 
 variable "eks_managed_node_groups" {
   description = "Map of managed node groups for the EKS cluster."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 
@@ -287,7 +287,7 @@ variable "eks_pod_identity_agent_options" {
 
 variable "fargate_profiles" {
   description = "Map of Fargate Profile definitions to create."
-  type        = map(any)
+  type        = any
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -239,7 +239,7 @@ variable "efs_csi_driver_values" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.5.2"
+  default     = "2.5.3"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EFS CSI Controller v2.5.3](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.5.3)

### Bug Fixes

* Change allowed type to `any` to allow nested maps in `cluster_security_group_additional_rules`, `eks_managed_node_groups`, and `fargate_profile` variables.