### PR TITLE
Release 0.6.5

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -6,7 +6,7 @@ locals {
 module "cert_manager_irsa" {
   count   = var.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -39,7 +39,7 @@ resource "helm_release" "crossplane" {
   values = [
     yamlencode({
       serviceAccount = {
-        annotations = {
+        customAnnotations = {
           "eks.amazonaws.com/role-arn" = module.crossplane_irsa[0].iam_role_arn
         }
       }

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -6,6 +6,7 @@ module "crossplane_irsa" {
 
   role_name = "${var.cluster_name}-crossplane-role"
 
+  assume_role_condition_test = "StringLike"
   oidc_providers = {
     main = {
       provider_arn = module.eks.oidc_provider_arn

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -39,7 +39,9 @@ resource "helm_release" "crossplane" {
   values = [
     yamlencode({
       provider = {
-        packages = var.crossplane_provider_packages
+        packages = [
+          for pkg in var.crossplane_provider_packages : try(pkg.package, "xpkg.upbound.io/crossplane-contrib/provider-${pkg.name}:v${pkg.version}")
+        ]
       }
     }),
     yamlencode(var.crossplane_values),

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -10,7 +10,7 @@ module "crossplane_irsa" {
     main = {
       provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = [
-        "${var.crossplane_namespace}:crossplane-system:provider-aws*",
+        "${var.crossplane_namespace}:${var.crossplane_service_account_name}",
       ]
     }
   }
@@ -37,13 +37,6 @@ resource "helm_release" "crossplane" {
   wait             = var.crossplane_wait
 
   values = [
-    yamlencode({
-      provider = {
-        packages = [
-          for pkg in var.crossplane_provider_packages : try(pkg.package, "xpkg.upbound.io/crossplane-contrib/provider-${pkg.name}:v${pkg.version}")
-        ]
-      }
-    }),
     yamlencode(var.crossplane_values),
   ]
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -38,10 +38,8 @@ resource "helm_release" "crossplane" {
 
   values = [
     yamlencode({
-      serviceAccount = {
-        customAnnotations = {
-          "eks.amazonaws.com/role-arn" = module.crossplane_irsa[0].iam_role_arn
-        }
+      provider = {
+        packages = var.crossplane_provider_packages
       }
     }),
     yamlencode(var.crossplane_values),

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -1,6 +1,6 @@
 ## Crossplane
 module "crossplane_irsa" {
-  count   = var.crossplane ? 1 : 0
+  count   = var.crossplane && var.crossplane_irsa ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.33.1"
 
@@ -18,7 +18,7 @@ module "crossplane_irsa" {
 }
 
 resource "aws_iam_role_policy_attachment" "crossplane" {
-  count      = var.crossplane ? length(var.crossplane_policy_arns) : 0
+  count      = var.crossplane && var.crossplane_irsa ? length(var.crossplane_policy_arns) : 0
   role       = module.crossplane_irsa[0].iam_role_name
   policy_arn = var.crossplane_policy_arns[count.index]
   depends_on = [
@@ -41,7 +41,6 @@ resource "helm_release" "crossplane" {
   ]
 
   depends_on = [
-    module.crossplane_irsa[0],
     module.eks,
   ]
 }

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -2,7 +2,7 @@
 module "crossplane_irsa" {
   count   = var.crossplane ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name = "${var.cluster_name}-crossplane-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -10,7 +10,7 @@ module "crossplane_irsa" {
     main = {
       provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = [
-        "${var.crossplane_namespace}:crossplane-system:provider-aws-*",
+        "${var.crossplane_namespace}:crossplane-system:provider-aws*",
       ]
     }
   }

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -4,7 +4,7 @@
 module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -25,7 +25,7 @@ resource "aws_efs_mount_target" "eks_efs_private" {
 module "eks_efs_csi_driver_irsa" {
   count   = var.efs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name = "${var.cluster_name}-efs-csi-driver-role"
 

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -4,7 +4,7 @@
 module "eks_lb_irsa" {
   count   = var.lb_controller ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,12 +30,12 @@ output "cluster_primary_security_group_id" {
 
 output "crossplane_role_arn" {
   description = "The Crossplane IRSA role Amazon Resource Name (ARN)"
-  value       = var.crossplane ? module.crossplane_irsa[0].iam_role_arn : null
+  value       = var.crossplane && var.crossplane_irsa ? module.crossplane_irsa[0].iam_role_arn : null
 }
 
 output "crossplane_role_name" {
   description = "The Crossplane IRSA role name"
-  value       = var.crossplane ? module.crossplane_irsa[0].iam_role_name : null
+  value       = var.crossplane && var.crossplane_irsa ? module.crossplane_irsa[0].iam_role_name : null
 }
 
 output "ebs_csi_driver_role_arn" {

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -6,7 +6,7 @@ module "eks_s3_csi_driver_irsa" {
   count = var.s3_csi_driver ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name = "${var.cluster_name}-s3-csi-driver-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -140,7 +140,7 @@ variable "crossplane_policy_arns" {
 }
 
 variable "crossplane_service_account_name" {
-  default     = "provider-aws-*"
+  default     = "provider-aws"
   description = "Crossplane service account name for IRSA binding."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,16 @@ variable "crossplane_policy_arns" {
   type        = list(string)
 }
 
+variable "crossplane_provider_packages" {
+  default = [
+    "xpkg.upbound.io/crossplane-contrib/provider-aws:v0.41.0",
+    "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.16.0",
+    "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.11.0",
+  ]
+  description = "Crossplane Provider packages to install by default."
+  type        = list(string)
+}
+
 variable "crossplane_values" {
   description = "Additional custom values for the Crossplane Helm chart."
   type        = any

--- a/variables.tf
+++ b/variables.tf
@@ -127,6 +127,12 @@ variable "crossplane" {
   default     = false
 }
 
+variable "crossplane_irsa" {
+  description = "Indicates whether to create an IRSA role for Crossplane."
+  type        = bool
+  default     = true
+}
+
 variable "crossplane_namespace" {
   default     = "crossplane-system"
   description = "Namespace that Crossplane will use."

--- a/variables.tf
+++ b/variables.tf
@@ -146,7 +146,7 @@ variable "crossplane_policy_arns" {
 }
 
 variable "crossplane_service_account_name" {
-  default     = "provider-aws"
+  default     = "provider-aws-*"
   description = "Crossplane service account name for IRSA binding."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -139,15 +139,10 @@ variable "crossplane_policy_arns" {
   type        = list(string)
 }
 
-variable "crossplane_provider_packages" {
-  default = [
-    {
-      name    = "aws"
-      version = "0.41.0"
-    },
-  ]
-  description = "List of maps of the Crossplane Provider packages to install."
-  type        = list(any)
+variable "crossplane_service_account_name" {
+  default     = "provider-aws-*"
+  description = "Crossplane service account name for IRSA binding."
+  type        = string
 }
 
 variable "crossplane_values" {

--- a/variables.tf
+++ b/variables.tf
@@ -141,12 +141,13 @@ variable "crossplane_policy_arns" {
 
 variable "crossplane_provider_packages" {
   default = [
-    "xpkg.upbound.io/crossplane-contrib/provider-aws:v0.41.0",
-    "xpkg.upbound.io/crossplane-contrib/provider-helm:v0.16.0",
-    "xpkg.upbound.io/crossplane-contrib/provider-kubernetes:v0.11.0",
+    {
+      name    = "aws"
+      version = "0.41.0"
+    },
   ]
-  description = "Crossplane Provider packages to install by default."
-  type        = list(string)
+  description = "List of maps of the Crossplane Provider packages to install."
+  type        = list(any)
 }
 
 variable "crossplane_values" {

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -2,7 +2,7 @@
 module "eks_vpc_cni_irsa" {
   count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.33.0"
+  version = "~> 5.33.1"
 
   role_name = "${var.cluster_name}-vpc-cni-role"
 


### PR DESCRIPTION
### Terraform Module Upgrades

* [`aws-iam` v5.33.1](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.33.1)

### New Features

* Add ability to override Crossplane's service name for IRSA with `crossplane_service_account_name` variable.

### Bug Fixes

* Fix invalid namespace service account specification in Crossplane's IRSA role and let the user do the EKS role annotation in their `ProviderConfig`.