### PR TITLE
Release 0.6.7

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -92,7 +92,7 @@ locals {
 module "cert_manager_irsa" {
   count   = var.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -2,7 +2,7 @@
 module "crossplane_irsa" {
   count   = var.crossplane && var.crossplane_irsa ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name = "${var.cluster_name}-crossplane-role"
 

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -4,7 +4,7 @@
 module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -25,7 +25,7 @@ resource "aws_efs_mount_target" "eks_efs_private" {
 module "eks_efs_csi_driver_irsa" {
   count   = var.efs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name = "${var.cluster_name}-efs-csi-driver-role"
 

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -4,7 +4,7 @@
 module "eks_lb_irsa" {
   count   = var.lb_controller ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -6,7 +6,7 @@ module "eks_s3_csi_driver_irsa" {
   count = var.s3_csi_driver ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name = "${var.cluster_name}-s3-csi-driver-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -400,7 +400,7 @@ variable "kube_proxy_options" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.28"
+  default     = "1.29"
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "cert_manager_values" {
 }
 
 variable "cert_manager_version" {
-  default     = "1.13.3"
+  default     = "1.14.0"
   description = "Version of cert-manager to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -424,7 +424,7 @@ variable "lb_controller_values" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.6.2"
+  default     = "1.7.0"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -357,16 +357,16 @@ variable "karpenter_values" {
   default     = {}
 }
 
+variable "karpenter_version" {
+  description = "Version of Karpenter Helm chart to install on the EKS cluster."
+  type        = string
+  default     = "0.33.2"
+}
+
 variable "karpenter_wait" {
   description = "Wait for the Karpenter Helm chart installation to complete."
   type        = bool
   default     = true
-}
-
-variable "karpenter_version" {
-  description = "Version of Karpenter Helm chart to install on the EKS cluster."
-  type        = string
-  default     = "0.33.1"
 }
 
 variable "kms_manage" {

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -2,7 +2,7 @@
 module "eks_vpc_cni_irsa" {
   count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.33.1"
+  version = "~> 5.34.0"
 
   role_name = "${var.cluster_name}-vpc-cni-role"
 


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS Load Balancer Controller v1.7.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.7.0)
* [`cert-manager` 1.14.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.0)
* [Karpenter 0.33.2](https://github.com/aws/karpenter-provider-aws/releases/tag/v0.33.2)

### Terraform Module Upgrades

* [`aws-iam` v5.34.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.34.0)

### Other

* Default Kubernetes version set to 1.29
* Upgrade of `aws-eks` to v20.x will wate for 0.7.x series due to backwards-incompatible changes.