### PR TITLE
Release 0.6.8

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -5,6 +5,7 @@ module "karpenter" {
 
   cluster_name                      = var.cluster_name
   create_access_entry               = false # re-evaluate when upgrading from v19.21.0
+  enable_irsa                       = true
   irsa_namespace_service_accounts   = ["${var.karpenter_namespace}:karpenter"]
   irsa_oidc_provider_arn            = module.eks.oidc_provider_arn
   node_iam_role_additional_policies = var.iam_role_additional_policies

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 
   # aws-auth configmap
-  aws_auth_node_iam_role_arns_non_windows = var.karpenter ? [module.karpenter[0].iam_role_arn] : []
+  aws_auth_node_iam_role_arns_non_windows = var.karpenter ? [module.karpenter[0].node_iam_role_arn] : []
   aws_auth_roles                          = local.aws_auth_roles
   manage_aws_auth_configmap               = true
 

--- a/main.tf
+++ b/main.tf
@@ -104,7 +104,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   cluster_security_group_additional_rules = var.cluster_security_group_additional_rules
 
   # aws-auth configmap
-  aws_auth_node_iam_role_arns_non_windows = var.karpenter ? [module.karpenter[0].role_arn] : []
+  aws_auth_node_iam_role_arns_non_windows = var.karpenter ? [module.karpenter[0].iam_role_arn] : []
   aws_auth_roles                          = local.aws_auth_roles
   manage_aws_auth_configmap               = true
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -63,24 +63,24 @@ output "eks_managed_node_groups" {
   value       = module.eks.eks_managed_node_groups
 }
 
-output "karpenter_pod_identity_role_arn" {
-  description = "The Amazon Resource Name (ARN) specifying the Pod Identity IAM role"
-  value       = var.karpenter ? module.karpenter[0].pod_identity_role_arn : null
+output "karpenter_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the controller IAM role"
+  value       = var.karpenter ? module.karpenter[0].iam_role_arn : null
 }
 
-output "karpenter_pod_identity_role_name" {
-  description = "The name of the Pod Identity IAM role"
-  value       = var.karpenter ? module.karpenter[0].pod_identity_role_name : null
+output "karpenter_iam_role_name" {
+  description = "The name of the controller IAM role"
+  value       = var.karpenter ? module.karpenter[0].iam_role_name : null
 }
 
-output "karpenter_role_arn" {
-  description = "The Amazon Resource Name (ARN) specifying the Karpenter IAM role"
-  value       = var.karpenter ? module.karpenter[0].role_arn : null
+output "karpenter_node_iam_role_arn" {
+  description = "The Amazon Resource Name (ARN) specifying the node IAM role"
+  value       = var.karpenter ? module.karpenter[0].node_iam_role_arn : null
 }
 
-output "karpenter_role_name" {
-  description = "The name of the Karpenter IAM role"
-  value       = var.karpenter ? module.karpenter[0].role_name : null
+output "karpenter_node_iam_role_name" {
+  description = "The name of the node IAM role"
+  value       = var.karpenter ? module.karpenter[0].node_iam_role_name : null
 }
 
 output "kms_key_arn" {

--- a/variables.tf
+++ b/variables.tf
@@ -263,7 +263,7 @@ variable "efs_csi_driver_values" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.5.4"
+  default     = "2.5.5"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "cert_manager_values" {
 }
 
 variable "cert_manager_version" {
-  default     = "1.14.0"
+  default     = "1.14.3"
   description = "Version of cert-manager to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -424,7 +424,7 @@ variable "lb_controller_values" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.7.0"
+  default     = "1.7.1"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -176,7 +176,7 @@ variable "crossplane_wait" {
 }
 
 variable "crossplane_version" {
-  default     = "1.14.5"
+  default     = "1.15.0"
   description = "Version of Crossplane Helm chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "karpenter_values" {
 variable "karpenter_version" {
   description = "Version of Karpenter Helm chart to install on the EKS cluster."
   type        = string
-  default     = "0.33.2"
+  default     = "0.34.1"
 }
 
 variable "karpenter_wait" {


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EFS CSI Controller v2.5.5](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.5.5)
* [AWS Load Balancer Controller v1.7.1](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.7.1)
* [`cert-manager` v1.14.3](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.3)
* [Crossplane v1.15.0](https://github.com/crossplane/crossplane/releases/tag/v1.15.0)
* [Karpenter v0.34.1](https://github.com/aws/karpenter-provider-aws/releases/tag/v0.34.1)


### Backwards-incompatible Changes

* Switch to using [`karpenter`](https://github.com/terraform-aws-modules/terraform-aws-eks/tree/v20.4.0/modules/karpenter) module from `aws-eks`.