### PR TITLE
Release 0.6.9

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -92,7 +92,7 @@ locals {
 module "cert_manager_irsa" {
   count   = var.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -2,7 +2,7 @@
 module "crossplane_irsa" {
   count   = var.crossplane && var.crossplane_irsa ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name = "${var.cluster_name}-crossplane-role"
 

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -4,7 +4,7 @@
 module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -25,7 +25,7 @@ resource "aws_efs_mount_target" "eks_efs_private" {
 module "eks_efs_csi_driver_irsa" {
   count   = var.efs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name = "${var.cluster_name}-efs-csi-driver-role"
 

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -4,7 +4,7 @@
 module "eks_lb_irsa" {
   count   = var.lb_controller ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true

--- a/main.tf
+++ b/main.tf
@@ -90,13 +90,21 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   create_cluster_security_group = var.karpenter ? false : var.create_cluster_security_group
   create_node_security_group    = var.karpenter ? false : var.create_node_security_group
 
+  # KMS key settings
   cluster_encryption_config = var.kms_manage ? {
     provider_key_arn = aws_kms_key.this[0].arn
     resources        = ["secrets"]
   } : { resources = ["secrets"] }
-  create_kms_key                  = var.kms_manage ? false : true
-  kms_key_deletion_window_in_days = var.kms_key_deletion_window_in_days
-  kms_key_enable_default_policy   = var.kms_key_enable_default_policy
+  create_kms_key                    = var.kms_manage ? false : true
+  enable_kms_key_rotation           = var.kms_key_enable_rotation
+  kms_key_administrators            = var.kms_key_administrators
+  kms_key_deletion_window_in_days   = var.kms_key_deletion_window_in_days
+  kms_key_enable_default_policy     = var.kms_key_enable_default_policy
+  kms_key_owners                    = var.kms_key_owners
+  kms_key_service_users             = var.kms_key_service_users
+  kms_key_users                     = var.kms_key_users
+  kms_key_source_policy_documents   = var.kms_key_source_policy_documents
+  kms_key_override_policy_documents = var.kms_key_override_policy_documents
 
   cluster_endpoint_private_access         = var.cluster_endpoint_private_access
   cluster_endpoint_public_access          = var.cluster_endpoint_public_access

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -6,7 +6,7 @@ module "eks_s3_csi_driver_irsa" {
   count = var.s3_csi_driver ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name = "${var.cluster_name}-s3-csi-driver-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -531,7 +531,7 @@ variable "nvidia_gpu_operator_values" {
 }
 
 variable "nvidia_gpu_operator_version" {
-  default     = "23.9.1"
+  default     = "23.9.2"
   description = "Version of the NVIDIA GPU Operator Helm chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -375,6 +375,18 @@ variable "kms_manage" {
   type        = bool
 }
 
+variable "kms_key_administrators" {
+  description = "A list of IAM ARNs for [key administrators](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-administrators). If no value is provided, the current caller identity is used to ensure at least one key admin is available"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_aliases" {
+  description = "A list of aliases to create. Note - due to the use of `toset()`, values must be static strings and not computed values"
+  type        = list(string)
+  default     = []
+}
+
 variable "kms_key_deletion_window_in_days" {
   description = "The waiting period, specified in number of days. After the waiting period ends, AWS KMS deletes the KMS key. If you specify a value, it must be between `7` and `30`, inclusive."
   type        = number
@@ -385,6 +397,42 @@ variable "kms_key_enable_default_policy" {
   description = "Specifies whether to enable the default key policy. Defaults to `true` to workaround EFS permissions."
   type        = bool
   default     = true
+}
+
+variable "kms_key_enable_rotation" {
+  description = "Specifies whether key rotation is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "kms_key_owners" {
+  description = "A list of IAM ARNs for those who will have full key permissions (`kms:*`)"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_override_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. In merging, statements with non-blank `sid`s will override statements with the same `sid`"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_service_users" {
+  description = "A list of IAM ARNs for [key service users](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-service-integration)"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_source_policy_documents" {
+  description = "List of IAM policy documents that are merged together into the exported document. Statements must have unique `sid`s"
+  type        = list(string)
+  default     = []
+}
+
+variable "kms_key_users" {
+  description = "A list of IAM ARNs for [key users](https://docs.aws.amazon.com/kms/latest/developerguide/key-policy-default.html#key-policy-default-allow-users)"
+  type        = list(string)
+  default     = []
 }
 
 variable "kube_proxy" {

--- a/variables.tf
+++ b/variables.tf
@@ -263,7 +263,7 @@ variable "efs_csi_driver_values" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.5.5"
+  default     = "2.5.6"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -41,7 +41,7 @@ variable "cert_manager_values" {
 }
 
 variable "cert_manager_version" {
-  default     = "1.14.3"
+  default     = "1.14.4"
   description = "Version of cert-manager to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -360,7 +360,7 @@ variable "karpenter_values" {
 variable "karpenter_version" {
   description = "Version of Karpenter Helm chart to install on the EKS cluster."
   type        = string
-  default     = "0.34.1"
+  default     = "0.35.1"
 }
 
 variable "karpenter_wait" {

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -2,7 +2,7 @@
 module "eks_vpc_cni_irsa" {
   count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.34.0"
+  version = "~> 5.37.1"
 
   role_name = "${var.cluster_name}-vpc-cni-role"
 


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EFS CSI Controller v2.5.6](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.5.6)
* [`cert-manager` v1.14.4](https://github.com/cert-manager/cert-manager/releases/tag/v1.14.4)
* [NVIDIA `gpu-operator` 23.9.2](https://github.com/NVIDIA/gpu-operator/releases/tag/v23.9.2)
* [Karpenter v0.35.1](https://github.com/aws/karpenter-provider-aws/releases/tag/v0.35.1)

### Terraform Module Upgrades

* [`aws-iam` v5.37.1](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.37.1)

### New Features

* Add `kms_key_*` variables so that is possible to manage all parameters of the KMS key.