### PR TITLE
Release 0.7.1

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -92,7 +92,7 @@ locals {
 module "cert_manager_irsa" {
   count   = var.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -2,7 +2,7 @@
 module "crossplane_irsa" {
   count   = var.crossplane && var.crossplane_irsa ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name = "${var.cluster_name}-crossplane-role"
 

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -4,7 +4,7 @@
 module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -25,7 +25,7 @@ resource "aws_efs_mount_target" "eks_efs_private" {
 module "eks_efs_csi_driver_irsa" {
   count   = var.efs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name = "${var.cluster_name}-efs-csi-driver-role"
 

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -1,7 +1,7 @@
 module "karpenter" {
   count   = var.karpenter ? 1 : 0
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.8.4"
+  version = "~> 20.8.5"
 
   cluster_name                      = var.cluster_name
   enable_irsa                       = true

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -4,7 +4,7 @@
 module "eks_lb_irsa" {
   count   = var.lb_controller ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
 # EKS Cluster
 module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-no-public-cluster-access tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.8.4"
+  version = "~> 20.8.5"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/main.tf
+++ b/main.tf
@@ -93,6 +93,7 @@ module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-
   create_kms_key                    = var.kms_manage ? false : true
   enable_kms_key_rotation           = var.kms_key_enable_rotation
   kms_key_administrators            = var.kms_key_administrators
+  kms_key_aliases                   = var.kms_key_aliases
   kms_key_deletion_window_in_days   = var.kms_key_deletion_window_in_days
   kms_key_enable_default_policy     = var.kms_key_enable_default_policy
   kms_key_owners                    = var.kms_key_owners

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -6,7 +6,7 @@ module "eks_s3_csi_driver_irsa" {
   count = var.s3_csi_driver ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name = "${var.cluster_name}-s3-csi-driver-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -199,16 +199,16 @@ variable "crossplane_values" {
   default     = {}
 }
 
+variable "crossplane_version" {
+  default     = "1.15.2"
+  description = "Version of Crossplane Helm chart to install."
+  type        = string
+}
+
 variable "crossplane_wait" {
   description = "Wait for the Crossplane Helm chart installation to complete."
   type        = bool
   default     = true
-}
-
-variable "crossplane_version" {
-  default     = "1.15.1"
-  description = "Version of Crossplane Helm chart to install."
-  type        = string
 }
 
 # The ECR repository is not the same for every region, in particular

--- a/variables.tf
+++ b/variables.tf
@@ -420,7 +420,7 @@ variable "karpenter_values" {
 variable "karpenter_version" {
   description = "Version of Karpenter Helm chart to install on the EKS cluster."
   type        = string
-  default     = "0.35.2"
+  default     = "0.36.0"
 }
 
 variable "karpenter_wait" {

--- a/variables.tf
+++ b/variables.tf
@@ -305,7 +305,7 @@ variable "efs_csi_driver_values" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "2.5.6"
+  default     = "2.5.7"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -2,7 +2,7 @@
 module "eks_vpc_cni_irsa" {
   count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.37.1"
+  version = "~> 5.39.0"
 
   role_name = "${var.cluster_name}-vpc-cni-role"
 


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EFS CSI Controller v2.5.7](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-2.5.7)
* [Crossplane v1.15.2](https://github.com/crossplane/crossplane/releases/tag/v1.15.2)
* [Karpenter v0.36.0](https://github.com/aws/karpenter-provider-aws/releases/tag/v0.36.0)

### Terraform Module Upgrades

* [`aws-eks` v20.8.5](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v20.8.5)
* [`aws-iam` v5.39.0](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.39.0)

### Bug Fixes

* Actually use the  `kms_key_aliases` variable.