### PR TITLE
Update the s3-csi controller service name to `s3-csi-driver-sa`

### DIFF
--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -14,7 +14,7 @@ module "eks_s3_csi_driver_irsa" {
     main = {
       provider_arn = module.eks.oidc_provider_arn
       namespace_service_accounts = [
-        "kube-system:mountpoint-s3-csi-controller-sa",
+        "kube-system:s3-csi-driver-sa",
       ]
     }
   }


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html#s3-create-iam-role 

"When you deploy the plugin in this procedure, it creates and is configured to use a service account named s3-csi-driver-sa."