### PR TITLE
Release 0.7.6

### DIFF
--- a/cert-manager.tf
+++ b/cert-manager.tf
@@ -92,7 +92,7 @@ locals {
 module "cert_manager_irsa" {
   count   = var.cert_manager ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name = "${var.cluster_name}-cert-manager-role"
 

--- a/crossplane.tf
+++ b/crossplane.tf
@@ -2,7 +2,7 @@
 module "crossplane_irsa" {
   count   = var.crossplane && var.crossplane_irsa ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name = "${var.cluster_name}-crossplane-role"
 

--- a/ebs-csi.tf
+++ b/ebs-csi.tf
@@ -4,7 +4,7 @@
 module "eks_ebs_csi_driver_irsa" {
   count   = var.ebs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name             = "${var.cluster_name}-ebs-csi-role"
   attach_ebs_csi_policy = true

--- a/efs-csi.tf
+++ b/efs-csi.tf
@@ -25,7 +25,7 @@ resource "aws_efs_mount_target" "eks_efs_private" {
 module "eks_efs_csi_driver_irsa" {
   count   = var.efs_csi_driver ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name = "${var.cluster_name}-efs-csi-driver-role"
 

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -1,7 +1,7 @@
 module "karpenter" {
   count   = var.karpenter ? 1 : 0
   source  = "terraform-aws-modules/eks/aws//modules/karpenter"
-  version = "~> 20.28.0"
+  version = "~> 20.33.1"
 
   cluster_name                      = var.cluster_name
   enable_irsa                       = true

--- a/lb-controller.tf
+++ b/lb-controller.tf
@@ -4,7 +4,7 @@
 module "eks_lb_irsa" {
   count   = var.lb_controller ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name                              = "${var.cluster_name}-lb-role"
   attach_load_balancer_controller_policy = true

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ locals {
 # EKS Cluster
 module "eks" { # tfsec:ignore:aws-ec2-no-public-egress-sgr tfsec:ignore:aws-eks-no-public-cluster-access tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 20.28.0"
+  version = "~> 20.33.1"
 
   cluster_name    = var.cluster_name
   cluster_version = var.kubernetes_version

--- a/s3-csi.tf
+++ b/s3-csi.tf
@@ -6,7 +6,7 @@ module "eks_s3_csi_driver_irsa" {
   count = var.s3_csi_driver ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name = "${var.cluster_name}-s3-csi-driver-role"
 

--- a/variables.tf
+++ b/variables.tf
@@ -200,7 +200,7 @@ variable "crossplane_values" {
 }
 
 variable "crossplane_version" {
-  default     = "1.18.0"
+  default     = "1.18.2"
   description = "Version of Crossplane Helm chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -59,7 +59,7 @@ variable "cert_manager_values" {
 }
 
 variable "cert_manager_version" {
-  default     = "1.16.1"
+  default     = "1.17.0"
   description = "Version of cert-manager to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -508,7 +508,7 @@ variable "kube_proxy_options" {
 }
 
 variable "kubernetes_version" {
-  default     = "1.31"
+  default     = "1.32"
   description = "Kubernetes version to use for the EKS cluster."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -305,7 +305,7 @@ variable "efs_csi_driver_values" {
 }
 
 variable "efs_csi_driver_version" {
-  default     = "3.0.8"
+  default     = "3.1.5"
   description = "Version of the EFS CSI storage driver to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -420,7 +420,7 @@ variable "karpenter_values" {
 variable "karpenter_version" {
   description = "Version of Karpenter Helm chart to install on the EKS cluster."
   type        = string
-  default     = "1.0.8"
+  default     = "1.2.1"
 }
 
 variable "karpenter_wait" {

--- a/variables.tf
+++ b/variables.tf
@@ -609,7 +609,7 @@ variable "nvidia_gpu_operator_values" {
 }
 
 variable "nvidia_gpu_operator_version" {
-  default     = "24.9.0"
+  default     = "24.9.2"
   description = "Version of the NVIDIA GPU Operator Helm chart to install."
   type        = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -544,7 +544,7 @@ variable "lb_controller_values" {
 }
 
 variable "lb_controller_version" {
-  default     = "1.10.0"
+  default     = "1.11.0"
   description = "Version of the AWS Load Balancer Controller chart to install."
   type        = string
 }

--- a/vpc-cni.tf
+++ b/vpc-cni.tf
@@ -2,7 +2,7 @@
 module "eks_vpc_cni_irsa" {
   count   = var.vpc_cni ? 1 : 0
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "~> 5.48.0"
+  version = "~> 5.52.2"
 
   role_name = "${var.cluster_name}-vpc-cni-role"
 


### PR DESCRIPTION
### Helm Chart Upgrades
    
* [AWS EFS CSI Controller v3.1.5](https://github.com/kubernetes-sigs/aws-efs-csi-driver/releases/tag/helm-chart-aws-efs-csi-driver-3.1.5)
* [AWS Load Balancer Controller v1.11.0](https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/tag/v2.11.0)
* [`cert-manager` v1.17.0](https://github.com/cert-manager/cert-manager/releases/tag/v1.17.0)
* [Crossplane v1.18.2](https://github.com/crossplane/crossplane/releases/tag/v1.18.2)
* [Karpenter v1.2.1](https://github.com/aws/karpenter-provider-aws/releases/tag/v1.2.1)
* [NVIDIA `gpu-operator` 24.9.2](https://github.com/NVIDIA/gpu-operator/releases/tag/v24.9.2)

### Terraform Module Upgrades

* [`aws-eks` v20.33.1](https://github.com/terraform-aws-modules/terraform-aws-eks/releases/tag/v20.33.1)
* [`aws-iam` v5.52.2](https://github.com/terraform-aws-modules/terraform-aws-iam/releases/tag/v5.52.2)

### Other

* Default Kubernetes version set to 1.32