### PR TITLE
Release 0.7.7

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -5,6 +5,7 @@ module "karpenter" {
 
   cluster_name                      = var.cluster_name
   enable_irsa                       = true
+  enable_v1_permissions             = !startswith(var.karpenter_version, "0.")
   irsa_namespace_service_accounts   = ["${var.karpenter_namespace}:karpenter"]
   irsa_oidc_provider_arn            = module.eks.oidc_provider_arn
   node_iam_role_additional_policies = var.iam_role_additional_policies

--- a/variables.tf
+++ b/variables.tf
@@ -642,12 +642,6 @@ variable "snapshot_controller_options" {
   default     = {}
 }
 
-variable "system_masters_roles" {
-  default     = ["PowerUsers"]
-  description = "Roles from the AWS account allowed system:masters to the EKS cluster."
-  type        = list(string)
-}
-
 variable "s3_csi_driver" {
   description = "Install and configure the S3 CSI storage driver addon."
   type        = bool


### PR DESCRIPTION
### Bug Fixes

* Automatically set `enable_v1_permissions` variable based on Karpenter version.
* Remove stale  and unused `system_masters_roles` variable.